### PR TITLE
Implement addresses for disambiguation

### DIFF
--- a/static/js/util.js
+++ b/static/js/util.js
@@ -514,8 +514,9 @@ function stationSearchAutocomplete(autoClass, visitedStations, url, manual) {
           data.features.forEach(function (item) {
             flag = getFlagEmoji(item.properties.countrycode);
             label = `${flag} ${item.properties.name}`;
+            disambiguation = item.properties.homonymy_order ? [item.properties.street, item.properties.locality, item.properties.district, item.properties.city].filter(e => (e)).join(", ") : null;
             displayLabel = label + (item.properties.homonymy_order ? item.properties.homonymy_order : "");
-            stationList.push({ "label": displayLabel, "value": displayLabel });
+            stationList.push({ "label": displayLabel, "value": displayLabel, "disambiguation": disambiguation });
             globalStationDict[displayLabel] = [item.geometry.coordinates.reverse(), label];
           });
 
@@ -559,8 +560,12 @@ function stationSearchAutocomplete(autoClass, visitedStations, url, manual) {
           .append("<div>" + item.label + "</div>")
           .appendTo(ul);
       } else {
+        var disambiguation = "";
+        if (item.disambiguation) {
+          disambiguation = " <span class='disambiguation'>" + item.disambiguation + "</span>"
+        }
         return $("<li>")
-          .append("<div>" + item.label + "</div>")
+          .append("<div>" + item.label + disambiguation + "</div>")
           .appendTo(ul);
       }
     };

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -557,19 +557,32 @@ function stationSearchAutocomplete(autoClass, visitedStations, url, manual) {
         return $("<li>")
           .addClass("manualStationSelect")
           .attr("text", manual)
-          .append("<div>" + item.label + "</div>")
+          .append("<div>" + sanitize(item.label) + "</div>")
           .appendTo(ul);
       } else {
         var disambiguation = "";
         if (item.disambiguation) {
-          disambiguation = " <span class='disambiguation'>" + item.disambiguation + "</span>"
+          disambiguation = " <span class='disambiguation'>" + sanitize(item.disambiguation) + "</span>"
         }
         return $("<li>")
-          .append("<div>" + item.label + disambiguation + "</div>")
+          .append("<div>" + sanitize(item.label) + disambiguation + "</div>")
           .appendTo(ul);
       }
     };
   });
+}
+
+function sanitize(string) {
+  const map = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+    "/": '&#x2F;',
+  };
+  const reg = /[&<>"'/]/ig;
+  return string.replace(reg, (match)=>(map[match]));
 }
 
 function manualCopyHandler(){

--- a/static/styles/style2.css
+++ b/static/styles/style2.css
@@ -399,6 +399,13 @@ body::before {
   background-color: #ffb4b43b;
 }
 
+.ui-autocomplete .disambiguation{
+  opacity: 0.5;
+  font-size: 75%;
+  padding-left: 1.75em;
+  display: block;
+}
+
 #operatorGroup .operatorLogoWrapper{
   display:inline-block;
   vertical-align: middle;


### PR DESCRIPTION
Basic implementation for disambiguating between multiple stops of the same name. This PR adds "street, locality, district, city" as a sub-text underneath results with the same name. 

<img width="534" height="596" alt="image" src="https://github.com/user-attachments/assets/85d5ed94-ec91-49f5-adf0-79552c10e712" />

No server impact expected; the data displayed is directly taken from the Photon autocompletion data. 

A separate draft PR will also be opened for discussion and previewing of an experimental version of this which shows more stop information from OSM via Overpass. 