### PR TITLE
Aerialways are no reason to show the "include private travels" setting

### DIFF
--- a/app.py
+++ b/app.py
@@ -934,7 +934,7 @@ def hasUncommonTrips(username):
             SELECT EXISTS (
                 SELECT 1
                 FROM trip
-                WHERE type NOT IN ('train', 'bus', 'air', 'ferry', 'helicopter', 'tram', 'metro')
+                WHERE type NOT IN ('train', 'bus', 'air', 'ferry', 'helicopter', 'tram', 'metro', 'aerialway')
                 AND username = :username
             ) AS has_uncommon_trips;
         """,


### PR DESCRIPTION
I haven't tested this. But just from how the code looks, I would expect this to fix the issue mentioned in https://discord.com/channels/1155959833535713412/1156264583527407626/1396401834490466407 