### PR TITLE
feat: ask user to confirm they want to leave page when editing path

### DIFF
--- a/templates/edit_copy.html
+++ b/templates/edit_copy.html
@@ -1445,5 +1445,18 @@
     });
 
 </script>
+<script defer>
+function beforeUnload(event) {
+    event.preventDefault();
+}
+
+//When the map modal is opened to edit the path, hook up window.beforeunload to ask the user if they really want to leave
+//When navigating away from the page.
+//removeEventListener -> addEventListener is to avoid multiple handler registrations.
+document.getElementById('mapModalButton').addEventListener('click', () => {
+    window.removeEventListener('beforeunload', beforeUnload);
+    window.addEventListener('beforeunload', beforeUnload);
+});
+</script>
 
 {% endblock %}

--- a/templates/routing.html
+++ b/templates/routing.html
@@ -90,6 +90,10 @@ async function saveTrip(continueTrip=false){
         }
     });
 }
+
+window.addEventListener('beforeunload', function (e) {
+    e.preventDefault();
+})
   </script>
 {% endblock %}
 


### PR DESCRIPTION
This PR is borne from personal frustration when editing paths on a smartphone and accidentally navigating to the previous page or refreshing the current page through gesture controls. In the current situation there's no "Are you sure?" check, all edits are lost, and the user has to redo their path editing from scratch. I've seen others deal with the same frustrations while traveling through Germany.

This PR adds a `beforeunload` handler to the `routing.html` page, as well as to the trip edit page when the *'Edit path'* button has been clicked at least once.

It leverages the built-in [beforeunload](https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event) event, which triggers when the user navigates away from the page or tries to refresh the page (but **not** when navigation happens through a form submit or from JS code) if the user has interacted with the page at all. Calling event.preventDefault() will cause the browser to prompt the user to confirm they're sure they want to leave.

<img width="434" height="196" alt="image" src="https://github.com/user-attachments/assets/05f8c966-d27b-47a2-8c8a-30b7b258a87f" />

This should help many smartphone users from accidentally throwing their path edits away.