### PR TITLE
Fix interpolation in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ start-db:
 
 # start the app only, locally (non-docker)
 start-local: start-db
-	env $(cat .env | xargs) POSTGRES_HOST=localhost FLASK_APP=app gunicorn --timeout 1000 --bind 0.0.0.0:5000 app:app --reload --access-logfile - --access-logformat '%(h)s %(r)s %(s)s'
+	env $$(cat .env | xargs) POSTGRES_HOST=localhost FLASK_APP=app gunicorn --timeout 1000 --bind 0.0.0.0:5000 app:app --reload --access-logfile - --access-logformat '%(h)s %(r)s %(s)s'
 
 # stop all containers
 stop:


### PR DESCRIPTION
In a Makefile, a `$` that should interpolate the result of another command, needs to be escaped with another `$`. See e.g. https://stackoverflow.com/a/44167334.