### PR TITLE
feat: allow autocompletion for vehicle types (`material_type`)

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,6 +101,7 @@ from py.sql import (
     getDynamicUserTrips,
     getLeaderboardCountries,
     getManualStationsQuery,
+    getMaterialTypes,
     getNumberStations,
     getOperators,
     getTags,
@@ -4670,6 +4671,14 @@ def getManAndOps(username, station_type):
                 getOperators, {"username": username}
             ).fetchall()
         ]
+    with managed_cursor(mainConn) as cursor:
+        # Fetching material types for station_type from the database
+        material_types_from_db = [
+            str(material_type["material_type"]).strip()
+            for material_type in cursor.execute(
+                getMaterialTypes, {"trip_type": station_type, "username": username}
+            ).fetchall()
+        ]
 
     # Getting the list of operators from the logos function
     operators_logos = listOperatorsLogos(tripType)
@@ -4685,9 +4694,12 @@ def getManAndOps(username, station_type):
         operator: operators_logos.get(operator, None) for operator in all_operators
     }
 
+    material_types = {material_type: None for material_type in material_types_from_db if material_type}
+
     manAndOps = {
         "operators": result,
         "manualStations": manualStations,
+        "materialTypes": material_types,
         "visitedStations": visitedStations,
     }
     return jsonify(manAndOps)

--- a/py/sql.py
+++ b/py/sql.py
@@ -13,6 +13,7 @@ getUserTrips = open("sql/getUserTrips.sql", "r").read()
 getUniqueUserTrips = open("sql/getUniqueUserTrips.sql", "r").read()
 getAllTrips = open("sql/getAllTrips.sql", "r").read()
 getOperators = open("sql/getOperators.sql", "r").read()
+getMaterialTypes = open("sql/getMaterialTypes.sql", "r").read()
 statsOperatorTrips = (
     open("sql/stats/CTEs/tripsCTE.sql", "r").read()
     + open("sql/stats/operators.sql", "r").read()

--- a/sql/getMaterialTypes.sql
+++ b/sql/getMaterialTypes.sql
@@ -1,0 +1,4 @@
+SELECT DISTINCT material_type
+FROM trip
+WHERE username = :username
+AND type = :trip_type

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -681,7 +681,7 @@ function operatorAutocomplete(select, manAndOps, logos_url, no_logo_url, type) {
   select.autocomplete({
     source: function (request, response) {
         // Normalize the search term
-        var searchTerm = request.term.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim(); 
+        var searchTerm = request.term.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
         var matches = $.map(Object.keys(manAndOps.operators), function (item) {
             // Normalize the comparison (for instance, replace 'č' with 'c')
             var normalizedItem = item.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
@@ -721,7 +721,38 @@ function operatorAutocomplete(select, manAndOps, logos_url, no_logo_url, type) {
   });
 }
 
+function materialTypeAutocomplete(select, manAndOps, type) {
+  select.autocomplete({
+    source: function (request, response) {
+        // Normalize the search term
+        var searchTerm = request.term.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
+        var matches = $.map(Object.keys(manAndOps.materialTypes), function (item) {
+            // Normalize the comparison (for instance, replace 'č' with 'c')
+            var normalizedItem = item.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
+            var index = normalizedItem.indexOf(searchTerm);
+            if (index !== -1) {
+                return {
+                    value: item,
+                    index: index
+                };
+            }
+            return null;
+        });
 
+        // Sort matches based on the position of the search term (index)
+        matches.sort(function (a, b) {
+            return a.index - b.index;
+        });
+
+        // Extract the sorted operator names
+        var sortedMaterialTypes = $.map(matches, function (match) {
+            return match.value;
+        });
+
+        response(sortedMaterialTypes);
+    }
+  });
+}
 
 
 function getRegionFromCode(region_code){

--- a/templates/edit_copy.html
+++ b/templates/edit_copy.html
@@ -1299,8 +1299,9 @@
         .done(function () { $(".operatorLogo").attr("src", origFilepath); })
         .fail(function () { $(".operatorLogo").attr("src", "{{ url_for('static',filename='images/icons/trip_logos/{}.png'.format(tripType))}}"); });
 
-    $.get('{{url_for("getManAndOps", username=username, station_type="*", tripType=tripType)}}', function (manAndOps, status) {
+    $.get('{{url_for("getManAndOps", username=username, station_type=tripType)}}', function (manAndOps, status) {
         operatorAutocomplete($("#operator"), manAndOps, "{{ url_for('static',filename='')}}", "{{ url_for('static',filename='images/icons/trip_logos/' + tripType + '.png')}}", "{{tripType}}");
+        materialTypeAutocomplete( $("#material_type"), manAndOps, "{{vehicle_type}}");
     });
 
 

--- a/templates/new.html
+++ b/templates/new.html
@@ -201,6 +201,7 @@
 
 
     operatorAutocomplete( $("#operator"), manAndOps, "{{ url_for('static',filename='')}}",  "{{ url_for('static',filename='images/icons/trip_logos/' + vehicle_type + '.png')}}", "{{vehicle_type}}");
+    materialTypeAutocomplete( $("#material_type"), manAndOps, "{{vehicle_type}}");
   });
 
 

--- a/templates/new_train.html
+++ b/templates/new_train.html
@@ -107,8 +107,8 @@
       manualStationsList.push({"label":station, "value":station, "manual":true})
     })
 
-    operatorAutocomplete( $("#operator"), manAndOps, "{{ url_for('static',filename='images/operator_logos/')}}",  "{{ url_for('static',filename='images/icons/trip_logos/train.png')}}");
-
+    operatorAutocomplete( $("#operator"), manAndOps, "{{ url_for('static',filename='images/operator_logos/')}}",  "{{ url_for('static',filename='images/icons/trip_logos/train.png')}}", "train");
+    materialTypeAutocomplete( $("#material_type"), manAndOps, "train");
   });
 
   


### PR DESCRIPTION
This resolves the feature request "Autocompletion for vehicle type" (with 19 upvotes).

I basically duplicated the autocompletion functionality for operators, but was able to simplify it heavily due to not having to care about logos.
This means, that all autocompletion suggestions just come from vehicle types *you* entered in any of *your* other trips. There is not centralized lists of things.