### PR TITLE
Split comma-separated material types in stats

### DIFF
--- a/sql/stats/materialType.sql
+++ b/sql/stats/materialType.sql
@@ -1,3 +1,33 @@
+,SplitMaterial AS (
+    SELECT
+        uid,
+        TRIM(IFNULL(NULLIF(SUBSTR(material_type, 1, INSTR(material_type, ',') - 1), ''), material_type)) AS material_type,
+        CASE
+            WHEN INSTR(material_type, ',') THEN TRIM(SUBSTR(material_type, INSTR(material_type, ',') + 1))
+            ELSE NULL
+        END AS rest,
+        past,
+        plannedFuture,
+        future
+    FROM counted
+    WHERE (:username IS NULL OR username = :username) AND future = 0
+
+    UNION ALL
+
+    SELECT
+        uid,
+        TRIM(IFNULL(NULLIF(SUBSTR(rest, 1, INSTR(rest, ',') - 1), ''), rest)),
+        CASE
+            WHEN INSTR(rest, ',') THEN TRIM(SUBSTR(rest, INSTR(rest, ',') + 1))
+            ELSE NULL
+        END,
+        past,
+        plannedFuture,
+        future
+    FROM SplitMaterial
+    WHERE rest IS NOT NULL AND TRIM(rest) <> ''
+)
+
 SELECT 
     CASE 
         WHEN :tripType IN ('air', 'helicopter') AND a.iata IS NOT NULL THEN a.manufacturer || ' ' || a.model
@@ -7,14 +37,9 @@ SELECT
     SUM(c.plannedFuture) AS plannedFuture,
     (SUM(c.past) + SUM(c.plannedFuture)) AS count
 FROM 
-    counted c
+    SplitMaterial c
 LEFT JOIN 
     airliners a ON c.material_type = a.iata
-WHERE 
-    (:username IS NULL OR c.username = :username)
-    AND c.future = 0
-    AND c.material_type IS NOT NULL
-    AND c.material_type != ''
 GROUP BY 
     CASE 
         WHEN :tripType IN ('air', 'helicopter') AND a.iata IS NOT NULL THEN a.manufacturer || ' ' || a.model


### PR DESCRIPTION
Resolves https://trainlog.me/feature_requests/11.

Don't ask me how it works, it is basically copying the comma-splitting magic from `sql/stats/newOperators.sql` and slightly adapting it.