### PR TITLE
Ignore diacritics in coverage search

### DIFF
--- a/static/js/util.js
+++ b/static/js/util.js
@@ -310,6 +310,11 @@ function truncate(input, length) {
   return input;
 };
 
+function normalizeForSearch(string) {
+  // Normalize the comparison (for instance, replace 'č' with 'c')
+  return string.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim()
+}
+
 function getTooltipFromStationNew(station){
   if (station != ""){
     flag = station.substring(0, 4);
@@ -681,10 +686,9 @@ function operatorAutocomplete(select, manAndOps, logos_url, no_logo_url, type) {
   select.autocomplete({
     source: function (request, response) {
         // Normalize the search term
-        var searchTerm = request.term.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
+        var searchTerm = normalizeForSearch(request.term);
         var matches = $.map(Object.keys(manAndOps.operators), function (item) {
-            // Normalize the comparison (for instance, replace 'č' with 'c')
-            var normalizedItem = item.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
+            var normalizedItem = normalizeForSearch(item);
             var index = normalizedItem.indexOf(searchTerm);
             if (index !== -1) {
                 return {
@@ -725,10 +729,10 @@ function materialTypeAutocomplete(select, manAndOps, type) {
   select.autocomplete({
     source: function (request, response) {
         // Normalize the search term
-        var searchTerm = request.term.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
+        var searchTerm = normalizeForSearch(request.term);
         var matches = $.map(Object.keys(manAndOps.materialTypes), function (item) {
             // Normalize the comparison (for instance, replace 'č' with 'c')
-            var normalizedItem = item.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
+            var normalizedItem = normalizeForSearch(item);
             var index = normalizedItem.indexOf(searchTerm);
             if (index !== -1) {
                 return {

--- a/templates/bootstrap/navigation.html
+++ b/templates/bootstrap/navigation.html
@@ -334,14 +334,14 @@
     $(".countries_menu").width("280px");
 
     $('.dropdown-search').on('input', function() {
-      var searchVal = $(this).val().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
+      var searchVal = normalizeForSearch($(this).val());
 
       // Loop through each continent group
       $(".countries_menu").each(function () {
         var anyVisible = false; // Flag to check if any countries are visible
 
         $(this).find('.countryLink').each(function() {
-          var countryText = $(this).text().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
+          var countryText = normalizeForSearch($(this).text());
           var isoCode = $(this).data('country').toLowerCase();
           if (countryText.includes(searchVal) || isoCode.includes(searchVal)) {
             $(this).show();

--- a/templates/bootstrap/navigation.html
+++ b/templates/bootstrap/navigation.html
@@ -334,14 +334,14 @@
     $(".countries_menu").width("280px");
 
     $('.dropdown-search').on('input', function() {
-      var searchVal = $(this).val().toLowerCase();
+      var searchVal = $(this).val().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
 
       // Loop through each continent group
       $(".countries_menu").each(function () {
         var anyVisible = false; // Flag to check if any countries are visible
 
         $(this).find('.countryLink').each(function() {
-          var countryText = $(this).text().toLowerCase();
+          var countryText = $(this).text().toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "").trim();
           var isoCode = $(this).data('country').toLowerCase();
           if (countryText.includes(searchVal) || isoCode.includes(searchVal)) {
             $(this).show();


### PR DESCRIPTION
Resolves https://trainlog.me/feature_requests/76.

Uses the same normalization as https://github.com/BorealBaguette/Trainlog/blob/59ce2122e81ea476aa187fbdfd5081eab8837242/static/js/util.js#L684

To not duplicate this line of code another two times, I instead factored it into its own function.