### PR TITLE
Put french overseas coverage maps to NA

### DIFF
--- a/app.py
+++ b/app.py
@@ -734,7 +734,7 @@ def get_country_codes_from_files():
             "KR", "LK", "SY", "TJ", "TH", "TR", "TM", "AE", "UZ", "VN", "YE", "TW",
             "HK"
         ],
-        "NA": ["CA", "US", "MX", "CU", "KN", "PR"],
+        "NA": ["CA", "US", "MX", "CU", "KN", "PR", "GP", "MQ"],
         "CA": ["BZ", "CR", "SV", "GT", "HN", "NI", "PA"],
         "SA": ["AR", "BO", "BR", "CL", "CO", "EC", "GY", "PY", "PE", "SR", "UY", "VE"],
         "OC": [


### PR DESCRIPTION
This gets rid of this error:
<img width="314" height="70" alt="image" src="https://github.com/user-attachments/assets/4b76fd3c-801a-432e-8c2b-adb0046eedc0" />

The other option would be to put these under french subdivisions. But IMO that does not fit well, as they are not a subset of the FR coverage map. Instead, I would handle them similar to e.g. Puerto Rico, which is my suggestion in this PR.