### PR TITLE
Reinstatiate fancy material autocompletion for airplanes

### DIFF
--- a/templates/edit_copy.html
+++ b/templates/edit_copy.html
@@ -1301,7 +1301,9 @@
 
     $.get('{{url_for("getManAndOps", username=username, station_type=tripType)}}', function (manAndOps, status) {
         operatorAutocomplete($("#operator"), manAndOps, "{{ url_for('static',filename='')}}", "{{ url_for('static',filename='images/icons/trip_logos/' + tripType + '.png')}}", "{{tripType}}");
-        materialTypeAutocomplete( $("#material_type"), manAndOps, "{{vehicle_type}}");
+        if (tripType != 'air') {
+            materialTypeAutocomplete( $("#material_type"), manAndOps, "{{vehicle_type}}");
+        }
     });
 
 


### PR DESCRIPTION
Resolves https://discord.com/channels/1155959833535713412/1156264583527407626/1405584386258108437.

Type `air` already adds it's own autocomplete a few lines down, so we currently have a race condition between the two autocomplete functions.