### PR TITLE
Fix column indices in search options

### DIFF
--- a/templates/dynamic_trips.html
+++ b/templates/dynamic_trips.html
@@ -1206,9 +1206,9 @@ $('#submitBtn').on('click', function() {
         'line:': 10,
         'country:': 11,
         'visibility:': 12,
-        'material:': 13,
-        'reg:': 14,
-        'notes:': 16
+        'material:': 14,
+        'reg:': 15,
+        'notes:': 17
     };
 
     // Parse search query for prefixes


### PR DESCRIPTION
Currently, one needs to use `reg:"flirt"` to find entries with "flirt" in the material_type field (instead of `material:"flirt"`). I would assume, that when adding the visibility option to the search filter, the indices in the front-end were not changed accordingly.