### PR TITLE
Fix date parsing for end_date in app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -6835,7 +6835,7 @@ def detect_precision(start_date, end_date):
         pass
 
     datetime.strptime(start_date, "%Y-%m-%d")
-    datetime.end_date(start_date, "%Y-%m-%d")
+    datetime.strptime(end_date, "%Y-%m-%d")
     return "onlyDate"
 
 


### PR DESCRIPTION
When importing a trainlog csv where trips don't have times there seems to be a syntax error in the parsing