### PR TITLE
Fix endpoint name for the `getBounds` endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -8689,7 +8689,7 @@ def trainloglogger(username):
     )
 
 
-@app.route("/getBounds/u/<username>")
+@app.route("/u/<username>/getBounds")
 @login_required
 def get_bounds(username):
     def get_location(lat, lon):

--- a/templates/bounds.html
+++ b/templates/bounds.html
@@ -165,7 +165,7 @@ function displayBoundsOnMap(data) {
 document.addEventListener("DOMContentLoaded", function() {
     const username = "{{ username }}";
     
-    fetch(`/getBounds/u/${username}`)
+    fetch(`/u/${username}/getBounds`)
         .then(r => r.json())
         .then(data => {
             document.getElementById("bounds-loading").style.display = "none";


### PR DESCRIPTION
For all other endpoints, the `/u/<username>/` is in the front, so this should be changed here as well