### PR TITLE
Optimize percent bar width to not have it covered by close icon

### DIFF
--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -698,10 +698,10 @@ nav .current{
 }
 
 .modeProportionContainer {
-  margin-top:5px;
-  margin-bottom:5px;
+  margin-top: 5px;
+  margin-bottom: 5px;
   max-width: 500px;
-  width:100%;
+  width: calc(100% - 40px); /* to make space for the x button on the old map on mobile devies */
 }
 
 .modeProportionIcon{

--- a/templates/public/new_trip.html
+++ b/templates/public/new_trip.html
@@ -230,8 +230,6 @@
                 <span class="text-nowrap"><i class="fas fa-route"></i> {{tag_description}}</span>
             {% endif %}
             </div>
-        {% else %}
-            <div class="itinerary_tag_description"><span><br></span></div>
         {% endif %}
             <div class="modeProportionContainer">
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 600" class="modeProportionIcon trip"><!--!Font Awesome Free v7.1.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2026 Fonticons, Inc.--><path d="M278.7 64.7C296 68.4 307 85.4 303.3 102.7L284.2 192L410.7 192L432.7 89.3C436.4 72 453.4 61 470.7 64.7C488 68.4 499 85.4 495.3 102.7L476.2 192L544 192C561.7 192 576 206.3 576 224C576 241.7 561.7 256 544 256L462.4 256L435 384L502.8 384C520.5 384 534.8 398.3 534.8 416C534.8 433.7 520.5 448 502.8 448L421.2 448L399.2 550.7C395.5 568 378.5 579 361.2 575.3C343.9 571.6 332.9 554.6 336.6 537.3L355.7 448L229.2 448L207.2 550.7C203.5 568 186.5 579 169.2 575.3C151.9 571.6 140.9 554.6 144.6 537.3L163.8 448L96 448C78.3 448 64 433.7 64 416C64 398.3 78.3 384 96 384L177.6 384L205 256L137.2 256C119.5 256 105.2 241.7 105.2 224C105.2 206.3 119.5 192 137.2 192L218.8 192L240.8 89.3C244.4 72 261.4 61 278.7 64.7zM270.4 256L243 384L369.5 384L396.9 256L270.4 256z"/></svg>


### PR DESCRIPTION
by reducing the width of the percent bar to 100%-40px.

Resolves the problem pointed out in https://discord.com/channels/1155959833535713412/1161603357182529607/1467857868647698475.