### PR TITLE
Nicer rounding of percent bars

### DIFF
--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -712,6 +712,7 @@ nav .current{
   margin-left:17px;
   height: 15px;
   border-radius: 10px;
+  overflow: hidden;
   text-align: center;
   vertical-align: middle;
   position: relative;
@@ -774,18 +775,6 @@ nav .current{
 
  .percent_bar.aerialway{
   background-color: var(--aerialway);
- }
-
-.percent_bar:first-child{
-  border-radius: 10px 0px 0px 10px;
- }
-
-.percent_bar:last-child{
-  border-radius: 0px 10px 10px 0px;
- }
-
-.percent_bar:only-child{
-  border-radius: 10px 10px 10px 10px;
  }
 
 .leaflet-sidebar {


### PR DESCRIPTION
before:
<img width="75" height="60" alt="image" src="https://github.com/user-attachments/assets/7b37b945-5c96-4d40-812f-9b3781a2a9bc" />


after:
<img width="88" height="55" alt="image" src="https://github.com/user-attachments/assets/59426e2e-08ea-48a6-aa61-ad989608deae" />

Together with https://github.com/BorealBaguette/Trainlog/pull/69, this looks even better