### PR TITLE
Return data after saving for app

### DIFF
--- a/app.py
+++ b/app.py
@@ -722,6 +722,7 @@ def saveTripToDb(username, newTrip, newPath, trip_type="train"):
     )
 
     create_trip(trip)
+    return trip
 
 
 def hasUncommonTrips(username):
@@ -4002,12 +4003,16 @@ def saveTrip(username):
         newPath = json.loads(jsonPath)
         jsonNewTrip = request.form["newTrip"]
         newTrip = json.loads(jsonNewTrip)
-        saveTripToDb(
+        trip = saveTripToDb(
             username=username,
             newTrip=newTrip,
             newPath=newPath,
             trip_type=newTrip["type"],
         )
+        if request.form["fromApp"] == "true":
+            return jsonify({
+                "newTrip": trip.to_dict(),
+            }), 200
 
     return ""
 

--- a/src/paths.py
+++ b/src/paths.py
@@ -11,6 +11,16 @@ class Node:
     def values(self):
         return tuple(vars(self).values())
 
+    def to_dict(self, *, include_trip_id: bool = False):
+        d = {
+            "node_order": self.node_order,
+            "lat": self.lat,
+            "lng": self.lng,
+        }
+        if include_trip_id:
+            d["trip_id"] = self.trip_id
+        return d
+
 
 class Path:
     def __init__(self, path, trip_id):
@@ -26,10 +36,35 @@ class Path:
 
     def values(self):
         return [self.list[0].trip_id, str([[node.lat, node.lng] for node in self.list])]
-    
+
     def __len__(self):
         return len(self.list)
 
     def set_trip_id(self, trip_id):
         for node in self.list:
             node.trip_id = trip_id
+
+    def to_dict(
+        self, *, include_trip_id: bool = True, include_node_order: bool = False
+    ):
+        """
+        JSON-ready dict.
+        - include_trip_id=True -> {"trip_id":..., "path":[...]}
+        - include_node_order controls whether each node has node_order
+        """
+        trip_id = self.list[0].trip_id if self.list else None
+        nodes = []
+        for n in self.list:
+            if include_node_order:
+                nodes.append({"lat": n.lat, "lng": n.lng, "node_order": n.node_order})
+            else:
+                nodes.append({"lat": n.lat, "lng": n.lng})
+
+        if include_trip_id:
+            return {"trip_id": trip_id, "path": nodes}
+        return {"path": nodes}
+
+    def to_json(self, **json_kwargs):
+        import json
+
+        return json.dumps(self.to_dict(), ensure_ascii=False, **json_kwargs)

--- a/src/trips/trip.py
+++ b/src/trips/trip.py
@@ -1,4 +1,9 @@
+import datetime
+import json
+from enum import Enum
+
 from src.carbon import calculate_carbon_footprint_for_trip
+from src.paths import Path
 from src.utils import get_username, managed_cursor, pathConn
 
 
@@ -114,3 +119,21 @@ class Trip:
             trip["trip_id"],
             trip["visibility"],
         )
+
+    def _json_safe(self, value):
+        if isinstance(value, (datetime.datetime, datetime.date)):
+            return value.isoformat()
+        if isinstance(value, Enum):
+            return value.value
+        if isinstance(value, set):
+            return list(value)
+        if isinstance(value, Path):
+            return value.to_dict(include_trip_id=True, include_node_order=False)
+        return value
+
+    def to_dict(self):
+        d = vars(self).copy()
+        return {k: self._json_safe(v) for k, v in d.items()}
+
+    def to_json(self, **json_kwargs):
+        return json.dumps(self.to_dict(), ensure_ascii=False, **json_kwargs)

--- a/templates/routing.html
+++ b/templates/routing.html
@@ -35,6 +35,7 @@ if (!newTrip) {
     throw new Error('No trip data');
 }
 
+var fromApp = !!getGetParams().get("fromApp");
 var type = getGetParams().get("type") || newTrip.type;
 newTrip["type"] = type;
 var freehand = getGetParams().get("freehand");
@@ -67,7 +68,8 @@ async function saveTrip(continueTrip=false) {
         url: '{{url_for("saveTrip", username=username)}}',
         data: {
             jsonPath: JSON.stringify(currentRoute),
-            newTrip: JSON.stringify(newTrip)
+            newTrip: JSON.stringify(newTrip),
+            fromApp: fromApp
         },
         success: function(res) {
             if (!continueTrip || newTrip.precision != "preciseDates") {


### PR DESCRIPTION
Return the JSON data of a freshly saved trip for app, in order to add it directly instead of fetching the list of the trip again.
The detection of the app is done by a GET parameter sent to the router

I tested it locally.

NB: this is only for *normal* routing, air routing will be done later.