### PR TITLE
Fix datetime handling in MOTIS

### DIFF
--- a/templates/motis_search.html
+++ b/templates/motis_search.html
@@ -763,12 +763,14 @@
     } else {
       formData.fromPlace = `${selectedFromPlace.lat},${selectedFromPlace.lon}`;
     }
+    formData.fromTz = selectedFromPlace.tz;
 
     if (selectedToPlace.id && selectedToPlace.type === 'STOP') {
       formData.toPlace = selectedToPlace.id;
     } else {
       formData.toPlace = `${selectedToPlace.lat},${selectedToPlace.lon}`;
     }
+    formData.toTz = selectedToPlace.tz;
     
     formData.fromName = selectedFromPlace.name;
     formData.toName = selectedToPlace.name;


### PR DESCRIPTION
The JavaScript code sends `arriveBy=false` if the checkbox is unchecked, so the presence of the key alone is not enough to set it to true.

Also, MOTIS needs timezone info in the timestamp, so I added the timezone MOTIS itself returns to the requests.