### PR TITLE
feat: Migrate operator data to Postgres + Split operator actions from app.py to own API blueprint

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,27 +4,19 @@
 # Standard Library Imports
 import calendar
 import csv
-import json
-import logging
 import logging.config
-import math
 import os
 import pathlib
 import re
 import secrets
-import smtplib
 import traceback
-import unicodedata as ud
 import urllib
 import uuid
 import xml.etree.ElementTree as ET
 import zipfile
 from collections import Counter, defaultdict
 from datetime import datetime, timedelta, UTC
-from email.mime.text import MIMEText
-from functools import wraps
 from glob import glob
-from inspect import getcallargs
 from io import BytesIO, StringIO
 from shapely.geometry import shape, mapping
 from shapely.ops import unary_union
@@ -60,7 +52,6 @@ from flask import (
 )
 from flask_caching import Cache
 from flask_compress import Compress
-from flask_sqlalchemy import SQLAlchemy
 from flaskext.autoversion import Autoversion
 from geopy.geocoders import Nominatim
 from PIL import Image
@@ -68,7 +59,6 @@ from requests.adapters import HTTPAdapter, Retry
 from scgraph.geographs.marnet import marnet_geograph
 from sqlalchemy import and_, case, func, or_
 from sqlalchemy_utils import database_exists
-from timezonefinder import TimezoneFinder
 from werkzeug.exceptions import HTTPException
 from werkzeug.security import check_password_hash, generate_password_hash
 from werkzeug.utils import secure_filename
@@ -150,7 +140,7 @@ from py.utils import (
     validate_png_file,
     time_ago
 )
-from src.api.admin import admin_blueprint
+from src.api.admin import admin_blueprint, operators_api_blueprint
 from src.api.feature_requests import feature_requests_blueprint
 from src.api.leaderboards import _getLeaderboardUsers
 from src.api.news import news_blueprint
@@ -218,6 +208,8 @@ Autoversion(app)
 app.url_map.strict_slashes = False
 
 app.register_blueprint(admin_blueprint, url_prefix="/admin")
+
+app.register_blueprint(operators_api_blueprint, url_prefix="/api/admin/operators")
 app.register_blueprint(feature_requests_blueprint)
 app.register_blueprint(finance_blueprint)
 app.register_blueprint(news_blueprint)
@@ -3346,83 +3338,6 @@ def borked_trips(username=None):
                     "affected_users": len(result),
                 }
             )
-
-@app.route("/admin/missing_operators")
-@admin_required
-def missing_operators():
-    with managed_cursor(mainConn) as main_cursor:
-        # Get all distinct operators from trips with their types and counts
-        main_cursor.execute("""
-            SELECT operator, type
-            FROM trip
-            WHERE operator IS NOT NULL AND operator != ''
-            AND type not in ('car', 'walk', 'cycle', 'poi', 'accommodation', 'restaurant')
-        """)
-        trip_rows = main_cursor.fetchall()
-        
-        if not trip_rows:
-            return jsonify({
-                "missing_operators": [],
-                "total_count": 0,
-                "by_type": {}
-            })
-        
-        # Split comma-separated operators and count them by type
-        operator_counts = {}  # {(operator, type): count}
-        for row in trip_rows:
-            operators = [op.strip() for op in str(row["operator"]).split(",")]
-            trip_type = row["type"]
-            for operator in operators:
-                if operator:  # Skip empty strings
-                    key = (operator, trip_type)
-                    operator_counts[key] = operator_counts.get(key, 0) + 1
-        
-        if not operator_counts:
-            return jsonify({
-                "missing_operators": [],
-                "total_count": 0,
-                "by_type": {}
-            })
-        
-        # Get all unique operators
-        all_operators = list(set(op for op, _ in operator_counts.keys()))
-        existing_operators = set()
-        
-        # Check which operators exist in batches
-        batch_size = 999
-        for i in range(0, len(all_operators), batch_size):
-            batch = all_operators[i : i + batch_size]
-            placeholders = ",".join(["?"] * len(batch))
-            main_cursor.execute(
-                f"SELECT DISTINCT short_name FROM operators WHERE short_name IN ({placeholders})",
-                batch
-            )
-            existing_operators.update(row["short_name"] for row in main_cursor.fetchall())
-        
-        # Build results by type
-        by_type = {}
-        total_occurrences = 0
-        
-        for (operator, trip_type), count in operator_counts.items():
-            if operator not in existing_operators:
-                if trip_type not in by_type:
-                    by_type[trip_type] = []
-                by_type[trip_type].append({
-                    "operator": operator,
-                    "occurrences": count
-                })
-                total_occurrences += count
-        
-        # Sort each type's operators by occurrences descending
-        for trip_type in by_type:
-            by_type[trip_type].sort(key=lambda x: x["occurrences"], reverse=True)
-        
-        return jsonify({
-            "missing_operators_by_type": by_type,
-            "total_occurrences": total_occurrences,
-            "unique_missing_operators": sum(len(ops) for ops in by_type.values())
-        })
-    
 
 @app.route("/admin/add_dummy_path/<trip_id>", methods=["GET"])
 @owner_required
@@ -8378,257 +8293,13 @@ os.makedirs(LOGO_UPLOAD_FOLDER, exist_ok=True)
 @app.route("/admin/operators", methods=["GET"])
 @admin_required
 def show_operators():
-    # Fetch all operators and their logos from the database
-    with managed_cursor(mainConn) as cursor:
-        cursor.execute("""
-            SELECT
-                o.uid,
-                o.short_name,
-                o.long_name,
-                o.alias_of,
-                o.operator_type,  -- New field
-                l.logo_url
-            FROM
-                operators o
-            LEFT JOIN operator_logos l ON l.operator_id = o.uid
-                AND l.rowid = (
-                    SELECT l1.rowid
-                    FROM operator_logos l1
-                    WHERE l1.operator_id = o.uid
-                    ORDER BY
-                        CASE WHEN l1.effective_date IS NULL THEN 1 ELSE 0 END ASC,
-                        l1.effective_date DESC
-                    LIMIT 1
-                );
-        """)
-        operator_list = cursor.fetchall()
-
     return render_template(
         "admin/operators.html",
         nav="bootstrap/navigation.html",
         username=getUser(),
-        operatorList=operator_list,
         **session["userinfo"],
         **lang[session["userinfo"]["lang"]],
     )
-
-
-@app.route("/admin/operators", methods=["POST"])
-@admin_required
-def add_operator():
-    short_name = request.form.get("short_name")
-    long_name = request.form.get("long_name")
-    alias_of = request.form.get("alias_of")
-    operator_type = request.form.get("operator_type")
-    logo = request.files.get("logo")
-    error_log_name = "logs/operator_logo_save_errors.txt"
-    log_name = "logs/operator_logo_log.txt"
-
-    try:
-        # Insert the operator into the database
-        with managed_cursor(mainConn) as cursor:
-            cursor.execute(
-                """
-                INSERT INTO operators (short_name, long_name, alias_of, operator_type)
-                VALUES (?, ?, ?, ?)
-            """,
-                (short_name, long_name, alias_of if alias_of else None, operator_type),
-            )
-
-            operator_id = cursor.lastrowid  # Get the inserted operator ID
-
-            # Handle the logo upload
-            if logo:
-                validate_png_file(logo)  # Validate the logo file
-                filename = secure_filename(
-                    f"{operator_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
-                )
-                logo.save(os.path.join(LOGO_UPLOAD_FOLDER, filename))
-
-                # Insert the logo into the operator_logos table
-                cursor.execute(
-                    """
-                    INSERT INTO operator_logos (operator_id, logo_url)
-                    VALUES (?, ?)
-                """,
-                    (operator_id, f"{REL_LOGO_UPLOAD_FOLDER}/{filename}"),
-                )
-
-        mainConn.commit()
-
-        # Log the successful addition to the save log
-        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        with open(log_name, "a", encoding="utf-8") as log:
-            log.write(
-                f"{current_time} - From: {getUser()} - Operator Added: {short_name} (ID: {operator_id})\n"
-            )
-
-        return jsonify(
-            {"status": "success", "message": "Operator added successfully."}
-        ), 200
-
-    except Exception as e:
-        # Log the error
-        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        with open(error_log_name, "a", encoding="utf-8") as log:
-            log.write(
-                f"{current_time} - From: {getUser()} - Error: {e} - File: {short_name}\n"
-            )
-        return jsonify({"status": "error", "message": str(e)}), 400
-
-
-@app.route("/admin/operators/update", methods=["POST"])
-@admin_required
-def update_operator():
-    uid = request.form.get("uid")
-    field = request.form.get("field")
-    value = request.form.get("value")
-    log_name = "logs/operator_logo_log.txt"
-
-    # Update the operator in the database
-    with managed_cursor(mainConn) as cursor:
-        cursor.execute(
-            f"""
-            UPDATE operators SET {field} = ? WHERE uid = ?
-        """,
-            (value, uid),
-        )
-
-    mainConn.commit()  # Commit the changes before returning the response
-
-    current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    with open(log_name, "a", encoding="utf-8") as log:
-        log.write(
-            f"{current_time} - From: {getUser()} - Operator Updated: Field '{field}' set to '{value}' (Operator ID: {uid})\n"
-        )
-
-    return jsonify({"status": "success", "message": "Operator updated successfully."})
-
-
-@app.route("/admin/operators/upload-logo", methods=["POST"])
-@admin_required
-def upload_logo():
-    uid = request.form.get("uid")
-    logo = request.files.get("logo")
-    effective_date = request.form.get("effective_date")
-    action = request.form.get("action")
-    error_log_name = "logs/operator_logo_save_errors.txt"
-    log_name = "logs/operator_logo_log.txt"
-
-    try:
-        if logo:
-            validate_png_file(logo)  # Validate the logo file
-
-            # Save the new logo with a unique name using a timestamp
-            filename = secure_filename(
-                f"{uid}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
-            )
-            logo.save(os.path.join(LOGO_UPLOAD_FOLDER, filename))
-
-            with managed_cursor(mainConn) as cursor:
-                cursor.execute(
-                    """
-                    INSERT INTO operator_logos (operator_id, logo_url, effective_date)
-                    VALUES (?, ?, ?)
-                """,
-                    (
-                        uid,
-                        f"{REL_LOGO_UPLOAD_FOLDER}/{filename}",
-                        effective_date if effective_date else None,
-                    ),
-                )
-
-            mainConn.commit()
-
-            # Log the successful upload to the save log
-            current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-            with open(log_name, "a", encoding="utf-8") as log:
-                log.write(
-                    f"{current_time} - From: {getUser()} - Logo {'Replaced' if action == 'replace' else 'Added'} for Operator ID: {uid} - Filename: {filename}\n"
-                )
-
-            return jsonify(
-                {"status": "success", "message": "Logo uploaded successfully."}
-            )
-
-    except Exception as e:
-        # Log the error
-        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        with open(error_log_name, "a", encoding="utf-8") as log:
-            log.write(
-                f"{current_time} - From: {getUser()} - Error: {e} - Operator ID: {uid}\n"
-            )
-        return jsonify({"status": "error", "message": str(e)}), 400
-
-
-@app.route("/admin/operators/delete", methods=["POST"])
-@admin_required
-def delete_operator():
-    uid = request.form.get("uid")
-
-    # Delete the operator and their logos from the database
-    with managed_cursor(mainConn) as cursor:
-        cursor.execute("DELETE FROM operator_logos WHERE operator_id = ?", (uid,))
-        cursor.execute("DELETE FROM operators WHERE uid = ?", (uid,))
-
-        # Delete all logos related to this operator from the filesystem
-        for file in os.listdir(LOGO_UPLOAD_FOLDER):
-            if file.startswith(f"{uid}_"):
-                logo_path = os.path.join(LOGO_UPLOAD_FOLDER, file)
-                if os.path.exists(logo_path):
-                    os.remove(logo_path)
-
-    mainConn.commit()
-    return jsonify(
-        {
-            "status": "success",
-            "message": "Operator and associated logos deleted successfully.",
-        }
-    )
-
-
-@app.route("/admin/operators/<int:uid>/logos", methods=["GET"])
-@admin_required
-def get_operator_logos(uid):
-    with managed_cursor(mainConn) as cursor:
-        cursor.execute(
-            """
-            SELECT uid, logo_url, effective_date FROM operator_logos WHERE operator_id = ? ORDER by effective_date
-        """,
-            (uid,),
-        )
-        logos = [
-            {
-                "uid": row["uid"],
-                "logo_url": row["logo_url"],
-                "effective_date": row["effective_date"],
-            }
-            for row in cursor.fetchall()
-        ]
-
-    return jsonify({"logos": logos})
-
-
-@app.route("/admin/operators/delete-logo", methods=["POST"])
-@admin_required
-def delete_logo():
-    logo_id = request.form.get("logo_id")
-    print(logo_id)
-
-    try:
-        with managed_cursor(mainConn) as cursor:
-            cursor.execute(
-                """
-                DELETE FROM operator_logos WHERE uid = ?
-            """,
-                (logo_id,),
-            )
-        mainConn.commit()
-        return jsonify({"status": "success", "message": "Logo deleted successfully."})
-
-    except Exception as e:
-        return jsonify({"status": "error", "message": str(e)}), 400
-
 
 @app.route("/migrate-logos")
 @owner_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ distinctipy==1.3.4
 Flask-Caching==2.3.1
 httpx==0.28.1
 scgraph==2.10.0
-pillow==10.4.0
+pillow==12.1.1
 CairoSVG==2.8.2
 pycountry==24.6.1
 geojson==3.2.0

--- a/src/api/admin/__init__.py
+++ b/src/api/admin/__init__.py
@@ -6,6 +6,8 @@ from py.utils import get_flag_emoji
 from src.suspicious_activity import list_denied_logins, list_suspicious_activity
 from src.utils import getUser, has_current_trip, lang, owner_required
 
+from .operators import operators_api_blueprint
+
 logger = logging.getLogger(__name__)
 
 admin_blueprint = Blueprint("admin", __name__)
@@ -61,3 +63,9 @@ def suspicious_activity():
         **lang[session["userinfo"]["lang"]],
         **session["userinfo"],
     )
+
+
+__all__ = [
+    "admin_blueprint",
+    "operators_api_blueprint",
+]

--- a/src/api/admin/operators.py
+++ b/src/api/admin/operators.py
@@ -38,12 +38,7 @@ def add_operator():
     if not logo:
         abort(400, description="logo is required")
 
-    if (
-        operator_type != "operator"
-        and operator_type != "accommodation"
-        and operator_type != "car"
-        and operator_type != "poi"
-    ):
+    if operator_type not in ("operator", "accommodation", "car", "poi"):
         abort(400, description="invalid operator_type")
 
     if len(short_name) == 0:
@@ -122,11 +117,6 @@ def get_operator_logos(operator_id: int):
 def add_operator_logo(operator_id: int):
     if not OperatorsRepository.operator_exists(operator_id):
         abort(404, description="operator not found")
-
-    logger.info("Content-Type: %s", request.content_type)
-    logger.info("Mimetype: %s", request.mimetype)
-    logger.info("Form keys: %s", list(request.form.keys()))
-    logger.info("Files keys: %s", list(request.files.keys()))
 
     logo = request.files.get("logo")
     effective_date = request.form.get("effective_date", type=parse_date)

--- a/src/api/admin/operators.py
+++ b/src/api/admin/operators.py
@@ -1,0 +1,240 @@
+import logging
+import os
+from datetime import datetime
+from typing import Literal
+
+from flask import Blueprint, abort, jsonify, request
+from sqlalchemy import bindparam, text
+from werkzeug.utils import secure_filename
+
+from py.utils import validate_png_file
+from src.operators import OperatorsRepository
+from src.pg import pg_session
+from src.utils import admin_required, getUser, parse_date
+
+logger = logging.getLogger(__name__)
+
+LOGO_UPLOAD_FOLDER = "static/images/operator_logos/new"
+os.makedirs(LOGO_UPLOAD_FOLDER, exist_ok=True)
+
+operators_api_blueprint = Blueprint("admin_operators", __name__)
+
+
+@operators_api_blueprint.route("", methods=["GET"])
+@admin_required
+def get_operators():
+    operators = OperatorsRepository.get_operators()
+    return jsonify({"operators": operators}), 200
+
+
+@operators_api_blueprint.route("", methods=["POST"])
+@admin_required
+def add_operator():
+    short_name = request.form.get("short_name")
+    long_name = request.form.get("long_name")
+    operator_type = request.form.get("operator_type")
+    logo = request.files.get("logo")
+
+    if not logo:
+        abort(400, description="logo is required")
+
+    if (
+        operator_type != "operator"
+        and operator_type != "accommodation"
+        and operator_type != "car"
+        and operator_type != "poi"
+    ):
+        abort(400, description="invalid operator_type")
+
+    if len(short_name) == 0:
+        abort(400, description="short_name is required")
+
+    if len(long_name) == 0:
+        abort(400, description="long_name is required")
+
+    try:
+        validate_png_file(logo)
+
+        operator = OperatorsRepository.add(short_name, long_name, operator_type)
+        operator_id = operator["operator_id"]
+
+        filename = secure_filename(
+            f"{operator_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
+        )
+        logo.save(os.path.join(LOGO_UPLOAD_FOLDER, filename))
+
+        OperatorsRepository.add_operator_logo(
+            operator_id, f"images/operator_logos/new/{filename}", None
+        )
+
+        # Log the successful addition to the save log
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open("logs/operator_logo_log.txt", "a", encoding="utf-8") as log:
+            log.write(
+                f"{current_time} - From: {getUser()} - Operator added: {short_name} (ID: {operator_id})\n"
+            )
+
+        return jsonify({"operator": operator}), 201
+    except Exception as e:
+        # Log the error
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open("logs/operator_logo_save_errors.txt", "a", encoding="utf-8") as log:
+            log.write(
+                f"{current_time} - From: {getUser()} - Error: {e} - Operator: {short_name}\n"
+            )
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@operators_api_blueprint.route(
+    "<int:operator_id>/<any(short_name, long_name, operator_type):field>",
+    methods=["PUT"],
+)
+@admin_required
+def update_operator_field(
+    operator_id: int, field: Literal["short_name", "long_name", "operator_type"]
+):
+    new_value = request.get_data(as_text=True)
+    if not OperatorsRepository.operator_exists(operator_id):
+        abort(404, description="operator not found")
+
+    result = OperatorsRepository.update_operator_field(operator_id, field, new_value)
+    if not result["success"]:
+        abort(400, description=result["error"])
+    return "", 204
+
+
+@operators_api_blueprint.route("<int:operator_id>", methods=["DELETE"])
+@admin_required
+def delete_operator(operator_id: int):
+    OperatorsRepository.delete(operator_id)
+    return "", 204
+
+
+@operators_api_blueprint.route("<int:operator_id>/logos", methods=["GET"])
+@admin_required
+def get_operator_logos(operator_id: int):
+    operator_logos = OperatorsRepository.get_operator_logos(operator_id)
+    return jsonify({"logos": operator_logos})
+
+
+@operators_api_blueprint.route("<int:operator_id>/logos", methods=["POST"])
+@admin_required
+def add_operator_logo(operator_id: int):
+    if not OperatorsRepository.operator_exists(operator_id):
+        abort(404, description="operator not found")
+
+    logger.info("Content-Type: %s", request.content_type)
+    logger.info("Mimetype: %s", request.mimetype)
+    logger.info("Form keys: %s", list(request.form.keys()))
+    logger.info("Files keys: %s", list(request.files.keys()))
+
+    logo = request.files.get("logo")
+    effective_date = request.form.get("effective_date", type=parse_date)
+
+    logger.info(len(request.form.keys()))
+    if not logo:
+        abort(400, description="logo is required")
+
+    try:
+        validate_png_file(logo)
+
+        filename = secure_filename(
+            f"{operator_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.png"
+        )
+        logo.save(os.path.join(LOGO_UPLOAD_FOLDER, filename))
+
+        operator_logo = OperatorsRepository.add_operator_logo(
+            operator_id, f"images/operator_logos/new/{filename}", effective_date
+        )
+
+        # Log the successful addition to the save log
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open("logs/operator_logo_log.txt", "a", encoding="utf-8") as log:
+            log.write(
+                f"{current_time} - From: {getUser()} - Logo Added for Operator ID: {operator_logo} - Filename: {filename}\n"
+            )
+
+        return jsonify({"logo": operator_logo}), 201
+    except Exception as e:
+        # Log the error
+        current_time = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        with open("logs/operator_logo_save_errors.txt", "a", encoding="utf-8") as log:
+            log.write(
+                f"{current_time} - From: {getUser()} - Error: {e} - Operator ID: {operator_id}\n"
+            )
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@operators_api_blueprint.route("logos/<int:logo_id>", methods=["DELETE"])
+@admin_required
+def delete_operator_logo(logo_id: int):
+    OperatorsRepository.delete_operator_logo(logo_id)
+    return "", 204
+
+
+@operators_api_blueprint.route("missing-operators", methods=["GET"])
+@admin_required
+def get_missing_operators():
+    with pg_session() as pg:
+        # Get all distinct operators from trips with their types and counts
+        result = pg.execute("""
+            SELECT operator, trip_type
+            FROM trips
+            WHERE operator IS NOT NULL
+              AND operator != ''
+              AND trip_type not in ('car', 'walk', 'cycle', 'poi', 'accommodation', 'restaurant')
+        """)
+        trip_rows = result.fetchall()
+
+        if not trip_rows or len(trip_rows) == 0:
+            return jsonify({"missing_operators": [], "total_count": 0, "by_type": {}})
+
+        # Split comma-separated operators and count them by type
+        operator_counts = {}  # {(operator, type): count}
+        for row in trip_rows:
+            operators = [op.strip() for op in str(row["operator"]).split(",")]
+            trip_type = row["trip_type"]
+            for operator in operators:
+                if operator:  # Skip empty strings
+                    key = (operator, trip_type)
+                    operator_counts[key] = operator_counts.get(key, 0) + 1
+
+        if not operator_counts:
+            return jsonify({"missing_operators": [], "total_count": 0, "by_type": {}})
+
+        # Get all unique operators
+        all_operators = list(set(op for op, _ in operator_counts.keys()))
+        existing_operators = set()
+
+        # Check which operators exist in batches
+        batch_size = 999
+        stmt = text(
+            "SELECT DISTINCT short_name FROM operators WHERE short_name IN :batch"
+        ).bindparams(bindparam("batch", expanding=True))
+        for i in range(0, len(all_operators), batch_size):
+            batch = all_operators[i : i + batch_size]
+            result = pg.execute(stmt, {"batch": batch})
+            existing_operators.update(row["short_name"] for row in result.fetchall())
+
+        # Build results by type
+        by_type = {}
+        total_occurrences = 0
+
+        for (operator, trip_type), count in operator_counts.items():
+            if operator not in existing_operators:
+                if trip_type not in by_type:
+                    by_type[trip_type] = []
+                by_type[trip_type].append({"operator": operator, "occurrences": count})
+                total_occurrences += count
+
+        # Sort each type's operators by occurrences descending
+        for trip_type in by_type:
+            by_type[trip_type].sort(key=lambda x: x["occurrences"], reverse=True)
+
+        return jsonify(
+            {
+                "missing_operators_by_type": by_type,
+                "total_occurrences": total_occurrences,
+                "unique_missing_operators": sum(len(ops) for ops in by_type.values()),
+            }
+        )

--- a/src/db_sync.py
+++ b/src/db_sync.py
@@ -266,19 +266,15 @@ def sync_operators_from_sqlite(pg_session=None):
         main_cursor.execute("SELECT count(*) FROM operators")
         num_operators = main_cursor.fetchone()[0]
         logger.info(f"Syncing {num_operators} operators from SQLite to PostgreSQL")
-        non_alias_operators = main_cursor.execute(
-            "SELECT * FROM operators WHERE alias_of IS NULL ORDER BY uid"
-        ).fetchall()
-        alias_operators = main_cursor.execute(
-            "SELECT * FROM operators WHERE alias_of IS NOT NULL ORDER BY uid"
+        all_operators = main_cursor.execute(
+            "SELECT * FROM operators ORDER BY uid"
         ).fetchall()
 
     with get_or_create_pg_session(pg_session) as pg:
         pg.execute("DELETE FROM operators;")
-        for i, row in enumerate(non_alias_operators):
+        for i, row in enumerate(all_operators):
             _insert_operator_into_pg(pg, row)
-        for i, row in enumerate(alias_operators):
-            _insert_operator_into_pg(pg, row)
+
         # reset ID sequence so future rows line up with SQLite
         pg.execute(
             "SELECT setval(pg_get_serial_sequence('operators', 'operator_id'),COALESCE((SELECT MAX(operator_id) FROM operators), 0),true)"
@@ -296,6 +292,7 @@ def sync_operators_from_sqlite(pg_session=None):
         pg.execute("DELETE FROM operator_logos;")
         for i, row in enumerate(operator_logos):
             _insert_operator_logo_into_pg(pg, row)
+
         # reset ID sequence so future rows line up with SQLite
         pg.execute(
             "SELECT setval(pg_get_serial_sequence('operator_logos', 'uid'),COALESCE((SELECT MAX(uid) FROM operator_logos), 0),true)"

--- a/src/db_sync.py
+++ b/src/db_sync.py
@@ -1,14 +1,14 @@
 import csv
 import io
-import logging
 import logging.config
 
 from src.pg import get_or_create_pg_session, pg_session
 from src.trips import Trip, compare_trip
-from src.utils import mainConn, managed_cursor, parse_date, authConn
+from src.utils import authConn, mainConn, managed_cursor, parse_date
 
 logging.config.fileConfig("logging.conf", disable_existing_loggers=False)
 logger = logging.getLogger(__name__)
+
 
 def get_user_id(username):
     with managed_cursor(authConn) as cursor:
@@ -33,6 +33,7 @@ def sync_db_from_sqlite():
     logger.info("Syncing SQLite database with PostgreSQL...")
     with pg_session() as pg:
         sync_trips_from_sqlite(pg)
+        sync_operators_from_sqlite(pg)
 
 
 def trip_to_csv(trip: Trip):
@@ -64,7 +65,7 @@ def trip_to_csv(trip: Trip):
         trip.currency,
         trip.ticket_id,
         trip.purchasing_date,
-        trip.visibility
+        trip.visibility,
     ]
     return items
 
@@ -186,6 +187,11 @@ def sync_trips_from_sqlite(pg_session=None):
         logger.info("Bulk inserting trips in pg...")
         cursor = pg.connection().connection.cursor()
         cursor.copy_expert(query, csv_buf)
+
+        # reset ID sequence so future rows line up with SQLite
+        pg.execute(
+            "SELECT setval(pg_get_serial_sequence('trips', 'trip_id'),COALESCE((SELECT MAX(trip_id) FROM trips), 0),true)"
+        )
     logger.info("Finished migrating trips from sqlite to pg!")
 
 
@@ -227,3 +233,72 @@ def compare_all_trips():
     except Exception:
         logger.error(f"Found exception while processing trip {trip_id}")
         raise
+
+
+def _insert_operator_into_pg(pg_session, operator):
+    pg_session.execute(
+        "INSERT INTO operators (operator_id, operator_type, short_name, long_name) VALUES (:id, :type, :short_name, :long_name)",
+        {
+            "id": operator["uid"],
+            "type": operator["operator_type"],
+            "short_name": operator["short_name"],
+            "long_name": operator["long_name"],
+        },
+    )
+
+
+def _insert_operator_logo_into_pg(pg_session, operator):
+    pg_session.execute(
+        "INSERT INTO operator_logos (uid, operator_id, logo_url, effective_date) VALUES (:uid, :operator_id, :logo_url, :effective_date)",
+        {
+            "uid": operator["uid"],
+            "operator_id": operator["operator_id"],
+            "logo_url": operator["logo_url"],
+            "effective_date": operator["effective_date"],
+        },
+    )
+
+
+def sync_operators_from_sqlite(pg_session=None):
+    logger.info("Step 1/2: Syncing operators from SQLite to PostgreSQL...")
+
+    with managed_cursor(mainConn) as main_cursor:
+        main_cursor.execute("SELECT count(*) FROM operators")
+        num_operators = main_cursor.fetchone()[0]
+        logger.info(f"Syncing {num_operators} operators from SQLite to PostgreSQL")
+        non_alias_operators = main_cursor.execute(
+            "SELECT * FROM operators WHERE alias_of IS NULL ORDER BY uid"
+        ).fetchall()
+        alias_operators = main_cursor.execute(
+            "SELECT * FROM operators WHERE alias_of IS NOT NULL ORDER BY uid"
+        ).fetchall()
+
+    with get_or_create_pg_session(pg_session) as pg:
+        pg.execute("DELETE FROM operators;")
+        for i, row in enumerate(non_alias_operators):
+            _insert_operator_into_pg(pg, row)
+        for i, row in enumerate(alias_operators):
+            _insert_operator_into_pg(pg, row)
+        # reset ID sequence so future rows line up with SQLite
+        pg.execute(
+            "SELECT setval(pg_get_serial_sequence('operators', 'operator_id'),COALESCE((SELECT MAX(operator_id) FROM operators), 0),true)"
+        )
+
+    logger.info("Step 2/2: Syncing operator logos from SQLite to PostgreSQL...")
+
+    with managed_cursor(mainConn) as main_cursor:
+        main_cursor.execute("SELECT count(*) from operator_logos")
+        num_logos = main_cursor.fetchone()[0]
+        logger.info(f"Syncing {num_logos} operator logos from SQLite to PostgreSQL")
+        operator_logos = main_cursor.execute("SELECT * FROM operator_logos").fetchall()
+
+    with get_or_create_pg_session(pg_session) as pg:
+        pg.execute("DELETE FROM operator_logos;")
+        for i, row in enumerate(operator_logos):
+            _insert_operator_logo_into_pg(pg, row)
+        # reset ID sequence so future rows line up with SQLite
+        pg.execute(
+            "SELECT setval(pg_get_serial_sequence('operator_logos', 'uid'),COALESCE((SELECT MAX(uid) FROM operator_logos), 0),true)"
+        )
+
+    logger.info("Finished migrating operators from sqlite to pg!")

--- a/src/operators.py
+++ b/src/operators.py
@@ -1,0 +1,191 @@
+import os
+from datetime import datetime
+from typing import Literal, NotRequired, TypedDict
+
+from src.pg import pg_session
+from src.utils import mainConn, managed_cursor
+
+LOGO_UPLOAD_FOLDER = "static/images/operator_logos/new"
+
+
+class OperatorsRepository:
+    # region SQLite functions
+    @staticmethod
+    def _add_sqlite(short_name: str, long_name: str, operator_type: str):
+        with managed_cursor(mainConn) as cursor:
+            cursor.execute(
+                "INSERT INTO operators (short_name, long_name, operator_type) VALUES (?, ?, ?)",
+                (short_name, long_name, operator_type),
+            )
+        mainConn.commit()
+
+    @staticmethod
+    def _update_operator_field_sqlite(
+        operator_id: int,
+        field: Literal["short_name", "long_name", "operator_type"],
+        value: str,
+    ):
+        with managed_cursor(mainConn) as cursor:
+            cursor.execute(
+                f"UPDATE operators SET {field} = :value WHERE uid = :operator_id",
+                {"value": value, "operator_id": operator_id},
+            )
+        mainConn.commit()
+
+    @staticmethod
+    def _delete_sqlite(operator_id: int):
+        with managed_cursor(mainConn) as cursor:
+            cursor.execute(
+                "DELETE FROM operator_logos WHERE operator_id = ?", (operator_id,)
+            )
+            cursor.execute("DELETE FROM operators WHERE uid = ?", (operator_id,))
+
+            for file in os.listdir(LOGO_UPLOAD_FOLDER):
+                if file.startswith(f"{operator_id}_"):
+                    logo_path = os.path.join(LOGO_UPLOAD_FOLDER, file)
+                    if os.path.exists(logo_path):
+                        os.remove(logo_path)
+
+            mainConn.commit()
+
+    @staticmethod
+    def _add_operator_logo_sqlite(
+        operator_id: int, logo_url: str, effective_date: datetime | None
+    ):
+        with managed_cursor(mainConn) as cursor:
+            cursor.execute(
+                "INSERT INTO operator_logos (operator_id, logo_url, effective_date) VALUES (?, ?, ?)",
+                (operator_id, logo_url, effective_date if effective_date else None),
+            )
+        mainConn.commit()
+
+    def _delete_operator_logo_sqlite(logo_id: int):
+        with managed_cursor(mainConn) as cursor:
+            cursor.execute("DELETE FROM operator_logos WHERE uid = ?", (logo_id,))
+        mainConn.commit()
+
+    # endregion
+
+    @classmethod
+    def get_operators(cls):
+        with pg_session() as pg:
+            result = pg.execute("""
+                SELECT o.operator_id, o.short_name, o.long_name, o.operator_type, ol.logo_url
+                FROM operators o
+                LEFT JOIN operator_logos ol ON ol.operator_id = o.operator_id AND ol.uid = (SELECT MAX(uid) FROM operator_logos WHERE operator_id=o.operator_id)
+            """)
+            columns = [
+                "operator_id",
+                "short_name",
+                "long_name",
+                "operator_type",
+                "logo_url",
+            ]
+            return [dict(zip(columns, row)) for row in result.fetchall()]
+
+    @classmethod
+    def operator_exists(cls, operator_id: int):
+        with pg_session() as pg:
+            result = pg.execute(
+                "SELECT 1 FROM operators WHERE operator_id = :operator_id",
+                {"operator_id": operator_id},
+            ).fetchone()
+            return result is not None
+
+    @classmethod
+    def add(cls, short_name: str, long_name: str, operator_type: str):
+        cls._add_sqlite(short_name, long_name, operator_type)
+        with pg_session() as pg:
+            result = pg.execute(
+                """
+                INSERT INTO operators (short_name, long_name, operator_type)
+                VALUES (:short_name, :long_name, :operator_type)
+                RETURNING operator_id, short_name, long_name, operator_type
+            """,
+                {
+                    "short_name": short_name,
+                    "long_name": long_name,
+                    "operator_type": operator_type,
+                },
+            )
+            columns = ["operator_id", "short_name", "long_name", "operator_type"]
+            return dict(zip(columns, result.fetchone()))
+
+    class UpdateOperatorFieldResult(TypedDict):
+        success: bool
+        error: NotRequired[str]
+
+    @classmethod
+    def update_operator_field(
+        cls,
+        operator_id: int,
+        field: Literal["short_name", "long_name", "operator_type"],
+        value: str,
+    ) -> UpdateOperatorFieldResult:
+        if (field == "short_name" or field == "long_name") and len(value) == 0:
+            return {
+                "success": False,
+                "error": "short_name and long_name cannot be empty.",
+            }
+        if field == "operator_type" and value not in (
+            "operator",
+            "accommodation",
+            "car",
+            "poi",
+        ):
+            return {"success": False, "error": "invalid operator_type"}
+
+        cls._update_operator_field_sqlite(operator_id, field, value)
+        with pg_session() as pg:
+            pg.execute(
+                f"UPDATE operators SET {field} = :value WHERE operator_id = :operator_id",
+                {"value": value, "operator_id": operator_id},
+            )
+            return {"success": True}
+
+    @classmethod
+    def delete(cls, operator_id: int):
+        cls._delete_sqlite(operator_id)
+        with pg_session() as pg:
+            pg.execute(
+                "DELETE FROM operators WHERE operator_id = :operator_id",
+                {"operator_id": operator_id},
+            )
+
+    @classmethod
+    def get_operator_logos(cls, operator_id: int):
+        with pg_session() as pg:
+            result = pg.execute(
+                "SELECT uid, operator_id, logo_url, effective_date FROM operator_logos WHERE operator_id = :operator_id",
+                {"operator_id": operator_id},
+            )
+            columns = ["uid", "operator_id", "logo_url", "effective_date"]
+            return [dict(zip(columns, row)) for row in result.fetchall()]
+
+    @classmethod
+    def add_operator_logo(
+        cls, operator_id: int, logo_url: str, effective_date: datetime | None
+    ):
+        cls._add_operator_logo_sqlite(operator_id, logo_url, effective_date)
+        with pg_session() as pg:
+            result = pg.execute(
+                """
+                INSERT INTO operator_logos (operator_id, logo_url, effective_date)
+                VALUES (:operator_id, :logo_url, :effective_date)
+                RETURNING uid, operator_id, logo_url, effective_date""",
+                {
+                    "operator_id": operator_id,
+                    "logo_url": logo_url,
+                    "effective_date": effective_date if effective_date else None,
+                },
+            )
+            columns = ["uid", "operator_id", "logo_url", "effective_date"]
+            return dict(zip(columns, result.fetchone()))
+
+    @classmethod
+    def delete_operator_logo(cls, logo_id: int):
+        cls._delete_operator_logo_sqlite(logo_id)
+        with pg_session() as pg:
+            pg.execute(
+                "DELETE FROM operator_logos WHERE uid = :logo_id", {"logo_id": logo_id}
+            )

--- a/src/sql/migrations/0014_operators.sql
+++ b/src/sql/migrations/0014_operators.sql
@@ -1,0 +1,1 @@
+ALTER SEQUENCE operator_logos_uid_seq RESTART WITH 3

--- a/src/sql/migrations/0014_operators.sql
+++ b/src/sql/migrations/0014_operators.sql
@@ -1,1 +1,13 @@
-ALTER SEQUENCE operator_logos_uid_seq RESTART WITH 3
+CREATE TABLE operators (
+    operator_id SERIAL PRIMARY KEY,
+    operator_type VARCHAR(100) NOT NULL,
+    short_name VARCHAR(100),
+    long_name VARCHAR(200)
+);
+
+CREATE TABLE operator_logos (
+    uid SERIAL PRIMARY KEY,
+    operator_id INTEGER NOT NULL references operators(operator_id) ON DELETE CASCADE,
+    logo_url TEXT,
+    effective_date DATE
+);

--- a/src/utils.py
+++ b/src/utils.py
@@ -447,10 +447,11 @@ def fr24_usage(username):
         row = cursor.fetchone() or (0,)
     return row[0]
 
+
 def check_and_increment_ai_usage(username, count=1, limit=10):
     month_key = datetime.utcnow().strftime("%Y-%m")
     is_premium = bool(User.query.filter_by(username=username).first().premium)
-    
+
     with managed_cursor(mainConn) as cursor:
         cursor.execute(
             """
@@ -472,11 +473,11 @@ def check_and_increment_ai_usage(username, count=1, limit=10):
                 """,
                 (username, month_key),
             )
-        
+
         # Check limit before incrementing (for non-premium)
         if not is_premium and ai_calls + count > limit:
             return False
-        
+
         # Increment usage
         cursor.execute(
             """
@@ -487,7 +488,7 @@ def check_and_increment_ai_usage(username, count=1, limit=10):
             (count, username, month_key),
         )
         mainConn.commit()
-    
+
     return True
 
 
@@ -506,6 +507,7 @@ def ai_usage(username):
         )
         row = cursor.fetchone() or (0,)
     return row[0]
+
 
 def get_default_trip_visibility(x):
     match x:

--- a/templates/admin/operators.html
+++ b/templates/admin/operators.html
@@ -116,49 +116,21 @@
     <table id="operatorTable" class="mt-3">
         <thead>
             <tr>
-                <th scope="col" data-priority=1>Short Name</th>
+                <th scope="col" data-priority=1>ID</th>
+                <th scope="col" data-priority=2>Short Name</th>
                 <th scope="col" data-priority=3>Long Name</th>
-                <th scope="col" data-priority=2>Alias Of</th>
                 <th scope="col" data-priority=4>Operator Type</th> <!-- New column for Operator Type -->
-                <th scope="col" data-priority=4 data-orderable="false">Logo</th>
+                <th scope="col" data-priority=5 data-orderable="false">Logo</th>
                 <th scope="col" data-orderable="false" data-priority=1>Actions</th>
             </tr>
         </thead>
         <tbody>
-            {% for operator in operatorList %}
-                <tr>
-                    <td contenteditable="true" onblur="updateOperator('{{ operator.uid }}', 'short_name', this.textContent)">
-                        {{ operator.short_name }}
-                    </td>
-                    <td contenteditable="true" onblur="updateOperator('{{ operator.uid }}', 'long_name', this.textContent)">
-                        {{ operator.long_name }}
-                    </td>
-                    <td>{{ operator.alias_of or 'N/A' }}</td>
-                    <td>
-                        <select class="operator-type-select" onchange="updateOperator('{{ operator.uid }}', 'operator_type', this.value)">
-                            <option value="operator" {% if operator.operator_type == 'operator' %}selected{% endif %}>Operator</option>
-                            <option value="accommodation" {% if operator.operator_type == 'accommodation' %}selected{% endif %}>Accommodation</option>
-                            <option value="car" {% if operator.operator_type == 'car' %}selected{% endif %}>Car</option>
-                            <option value="poi" {% if operator.operator_type == 'poi' %}selected{% endif %}>POI</option>
-                        </select>
-                    </td>
-                    <td>
-                        <img src="/static/{{ operator.logo_url }}" width="100px" loading="lazy" id="logo-img-{{ operator.uid }}" 
-                             onclick="showLogoCarousel('{{ operator.uid }}');" style="cursor: pointer;">
-                    </td>
-                    <td>
-                        <button class="btn btn-danger btn-sm" onclick="deleteOperator('{{ operator.uid }}')">
-                            <i class="fa-regular fa-trash-can"></i>
-                        </button>
-                    </td>
-                </tr>
-            {% endfor %}
         </tbody>
     </table>
 </div>
 
 <!-- Modal for Missing Operators -->
-<div class="modal fade" id="missingOperatorsModal" tabindex="-1" aria-labelledby="missingOperatorsModalLabel" aria-hidden="true">
+<div class="modal fade" id="missingOperatorsModal" tabindex="-1" aria-labelledby="missingOperatorsModalLabel" aria-hidden="true" style="top: 50px">
     <div class="modal-dialog modal-xl modal-dialog-centered modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
@@ -240,10 +212,6 @@
                         <input type="text" class="form-control" id="long_name" name="long_name" required>
                     </div>
                     <div class="form-group">
-                        <label for="alias_of">Alias Of (Optional)</label>
-                        <input type="text" class="form-control" id="alias_of" name="alias_of">
-                    </div>
-                    <div class="form-group">
                         <label for="operator_type">Operator Type</label> <!-- New select field for Operator Type -->
                         <select class="form-select" id="operator_type" name="operator_type" required>
                             <option value="operator">Operator</option>
@@ -263,26 +231,6 @@
     </div>
 </div>
 
-<!-- Success Modal -->
-<div class="modal fade" id="successModal" tabindex="-1" aria-labelledby="successModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-      <div class="modal-content">
-        <div class="modal-header">
-          <h5 class="modal-title" id="successModalLabel">Success</h5>
-          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-        </div>
-        <div class="modal-body">
-          <p id="successModalMessage">Operator added successfully!</p>
-        </div>
-        <div class="modal-footer">
-          <!-- When clicked, this will reload the page -->
-          <button type="button" class="btn btn-primary" id="successModalOkButton">
-            OK
-          </button>
-        </div>
-      </div>
-    </div>
-  </div>
   
   <!-- Error Modal -->
   <div class="modal fade" id="errorModal" tabindex="-1" aria-labelledby="errorModalLabel" aria-hidden="true">
@@ -306,72 +254,114 @@
   </div>  
 
 <!-- JavaScript -->
-<script>
-let currentUid = null;
-    $(document).ready(function() {
-        $('#operatorTable').DataTable({
-            responsive: true,
-            columnDefs: [{
-                targets: [3],
-                render: function (data, type, row) {
-                    if (type === 'display') {
-                        return data; // display the select element as is
-                    } else {
-                        // For filtering and sorting, return the selected option's text
-                        var $cell = $('<div>').html(data);
-                        var selectedText = $cell.find('option:selected').text();
-                        return selectedText;
-                    }
-                }
-            }]
-        });
+<script defer>
+    let currentUid = null;
 
-        $('#operatorForm').on('submit', function(e) {
-            e.preventDefault();
-            const formData = new FormData(this);
-
-            $.ajax({
-                type: 'POST',
-                url: '/admin/operators',
-                data: formData,
-                contentType: false,
-                processData: false,
-                success: function(response) {
-                    $('#successModalMessage').text(response.message || 'Operator added successfully!');
-                    $('#operatorModal').modal('hide');
-
-                    $('#operatorModal').on('hidden.bs.modal', function () {
-                        $('#successModal').modal('show');
-                        $('#operatorModal').off('hidden.bs.modal'); // clean up handler
-                    });
-
-                    $('#successModalOkButton').off('click').on('click', function () {
-                        location.reload();
-                    });
+    const table = $('#operatorTable').DataTable({
+        responsive: true,
+        ajax: {
+            url: '/api/admin/operators',
+            dataSrc: 'operators'
+        },
+        columns: [
+            { data: 'operator_id', searchable: true, orderable: true },
+            {
+                data: 'short_name',
+                searchable: true,
+                orderable: true,
+                render(data, type, row) {
+                    if (type === 'display')
+                        return `<span style="display: block" contenteditable="true" onblur="updateOperator(${row.operator_id}, 'short_name', this.textContent)">${data}</span>`
+                    else return data;
                 },
-                error: function(error) {
-                    const errMsg = (error.responseJSON && error.responseJSON.message)
-                        ? error.responseJSON.message
-                        : 'An error occurred while adding the operator.';
-
-                    $('#errorModalMessage').text(errMsg);
-
-                    $('#operatorModal').modal('hide');
-
-                    $('#operatorModal').on('hidden.bs.modal', function () {
-                        $('#errorModal').modal('show');
-                        $('#operatorModal').off('hidden.bs.modal'); // clean up
-                    });
-
-                    // After error modal is closed, re-open the operator form
-                    $('#errorModal').on('hidden.bs.modal', function () {
-                        $('#operatorModal').modal('show');
-                        $('#errorModal').off('hidden.bs.modal'); // clean up
-                    });
+            },
+            {
+                data: 'long_name',
+                searchable: true,
+                orderable: true,
+                render(data, type, row) {
+                    if (type === 'display')
+                        return `<span style="display: block" contenteditable="true" onblur="updateOperator(${row.operator_id}, 'long_name', this.textContent)">${data}</span>`
+                    else return data;
+                },
+            },
+            {
+              data: 'operator_type',
+              searchable: true,
+              render(data, type, row) {
+                if(type === 'display') {
+                    return `<select class="operator-type-select" onchange="updateOperator('${row.operator_id}', 'operator_type', this.value)">#}
+                        <option value="operator" ${data === 'operator' && 'selected'}>Operator</option>#}
+                        <option value="accommodation" ${data === 'accommodation' && 'selected'}>Accommodation</option>#}
+                        <option value="car" ${data === 'car' && 'selected'}>Car</option>#}
+                        <option value="poi" ${data === 'poi' && 'selected'}>POI</option>#}
+                   </select>`
+                } else {
+                  return data;
                 }
+              }
+            },
+            {
+              data: 'logo_url',
+              searchable: false,
+              orderable: false,
+              render(data, type, row) {
+                if (type === 'display')
+                    return `<img src="/static/${data}" width="100px" loading="lazy" id="logo-img-${row.operator_id}"` +
+                    `alt="logo for ${row.short_name}" onclick="showLogoCarousel(${row.operator_id})" style="cursor: pointer;"">`
+                else
+                    return data;
+              }
+            },
+            {
+                data: null,
+                searchable: false,
+                orderable: false,
+                render(data, type, row) {
+                    if (type === 'display')
+                        return `<button class="btn btn-danger btn-sm" onclick="deleteOperator(${ row.operator_id })">
+                          <i class="fa-regular fa-trash-can"></i>
+                        </button>`
+                    else
+                        return data;
+                }
+            }
+        ]
+    });
+
+    const operatorForm = document.getElementById('operatorForm');
+    operatorForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const formData = new FormData(operatorForm);
+
+        fetch('/api/admin/operators', {
+            method: 'POST',
+            body: formData
+        }).then((res) => {
+            if(res.status > 299)
+                res.text().then(err => {
+                    throw new Error(err)
+                })
+
+            $('#operatorModal').modal('hide');
+            table.ajax.reload();
+            res.json().then((json) => {
+                bootstrapToast(`Operator ${json.operator.short_name} added successfully! new id: ${json.operator.operator_id}`)
+            })
+        }).catch(() => {
+            $('#errorModalMessage').text('An error occurred while adding the operator.');
+            $('#operatorModal').modal('hide');
+            $('#operatorModal').on('hidden.bs.modal', function () {
+                $('#errorModal').modal('show');
+                $('#operatorModal').off('hidden.bs.modal'); // clean up
+            });
+
+            // After error modal is closed, re-open the operator form
+            $('#errorModal').on('hidden.bs.modal', function () {
+                $('#operatorModal').modal('show');
+                $('#errorModal').off('hidden.bs.modal'); // clean up
             });
         });
-
     });
 
     function loadMissingOperators() {
@@ -383,161 +373,165 @@ let currentUid = null;
             </div>
         `);
 
-        $.ajax({
-            type: 'GET',
-            url: '/admin/missing_operators',
-            success: function(response) {
-                if (response.unique_missing_operators === 0) {
-                    $('#missingOperatorsContent').html(`
-                        <div class="alert alert-success" role="alert">
-                            <h4 class="alert-heading">Great!</h4>
-                            <p>No missing operators found. All operators from your trips are already in the database.</p>
-                        </div>
-                    `);
-                    return;
-                }
+        fetch('/api/admin/operators/missing-operators').then((res) => {
+            if(res.status > 299) {
+                res.text().then(err => { throw new Error(err) });
+                return;
+            }
 
-                // Collect all operators across all types for top 10
-                let allOperators = [];
-                Object.keys(response.missing_operators_by_type).forEach(type => {
-                    response.missing_operators_by_type[type].forEach(op => {
-                        allOperators.push({
-                            operator: op.operator,
-                            occurrences: op.occurrences,
-                            type: type
-                        });
+            return res.json();
+        }).then((response) => {
+            if (response.unique_missing_operators === 0) {
+                $('#missingOperatorsContent').html(`
+                    <div class="alert alert-success" role="alert">
+                        <h4 class="alert-heading">Great!</h4>
+                        <p>No missing operators found. All operators from your trips are already in the database.</p>
+                    </div>
+                `);
+                return;
+            }
+
+            // Collect all operators across all types for top 10
+            let allOperators = [];
+            Object.keys(response.missing_operators_by_type).forEach(type => {
+                response.missing_operators_by_type[type].forEach(op => {
+                    allOperators.push({
+                        operator: op.operator,
+                        occurrences: op.occurrences,
+                        type: type
                     });
                 });
+            });
 
-                // Sort by occurrences and get top 10
-                allOperators.sort((a, b) => b.occurrences - a.occurrences);
-                const top10 = allOperators.slice(0, 10);
+            // Sort by occurrences and get top 10
+            allOperators.sort((a, b) => b.occurrences - a.occurrences);
+            const top10 = allOperators.slice(0, 10);
 
-                let html = `
-                    <div class="mb-4">
-                        <div class="d-flex justify-content-between align-items-center mb-3">
-                            <h6 class="mb-0">Summary</h6>
-                            <div>
-                                <span class="badge bg-primary">${response.unique_missing_operators} unique operators</span>
-                                <span class="badge bg-secondary">${response.total_occurrences} total occurrences</span>
-                            </div>
+            let html = `
+                <div class="mb-4">
+                    <div class="d-flex justify-content-between align-items-center mb-3">
+                        <h6 class="mb-0">Summary</h6>
+                        <div>
+                            <span class="badge bg-primary">${response.unique_missing_operators} unique operators</span>
+                            <span class="badge bg-secondary">${response.total_occurrences} total occurrences</span>
                         </div>
                     </div>
+                </div>
 
-                    <div class="top-operators-card">
-                        <h6 class="mb-3"><i class="fa-solid fa-star"></i> Top 10 Most Common Missing Operators</h6>
-                        <div class="operator-list">
+                <div class="top-operators-card">
+                    <h6 class="mb-3"><i class="fa-solid fa-star"></i> Top 10 Most Common Missing Operators</h6>
+                    <div class="operator-list">
+            `;
+
+            top10.forEach((op, index) => {
+                html += `
+                    <div class="operator-list-item">
+                        <div>
+                            <strong>${index + 1}. ${op.operator}</strong>
+                            <span class="badge bg-light text-dark ms-2">${op.type}</span>
+                        </div>
+                        <span class="badge bg-warning text-dark">${op.occurrences} occurrences</span>
+                    </div>
+                `;
+            });
+
+            html += `
+                    </div>
+                </div>
+                <hr>
+                <h6 class="mb-3">All Missing Operators by Type</h6>
+                <div class="accordion" id="operatorTypesAccordion">
+            `;
+
+            const sortedTypes = Object.keys(response.missing_operators_by_type).sort((a, b) => {
+                const aTotal = response.missing_operators_by_type[a].reduce((sum, op) => sum + op.occurrences, 0);
+                const bTotal = response.missing_operators_by_type[b].reduce((sum, op) => sum + op.occurrences, 0);
+                return bTotal - aTotal;
+            });
+
+            sortedTypes.forEach((type, index) => {
+                const operators = response.missing_operators_by_type[type];
+                const totalOccurrences = operators.reduce((sum, op) => sum + op.occurrences, 0);
+                const isFirst = index === 0;
+
+                html += `
+                    <div class="accordion-item">
+                        <h2 class="accordion-header" id="heading-${type}">
+                            <button class="accordion-button ${isFirst ? '' : 'collapsed'}" type="button"
+                                    data-bs-toggle="collapse" data-bs-target="#collapse-${type}"
+                                    aria-expanded="${isFirst ? 'true' : 'false'}" aria-controls="collapse-${type}">
+                                <strong class="text-capitalize">${type}</strong>
+                                <span class="ms-auto me-3">
+                                    <span class="badge bg-primary">${operators.length} operators</span>
+                                    <span class="badge bg-secondary">${totalOccurrences} occurrences</span>
+                                </span>
+                            </button>
+                        </h2>
+                        <div id="collapse-${type}" class="accordion-collapse collapse ${isFirst ? 'show' : ''}"
+                             aria-labelledby="heading-${type}" data-bs-parent="#operatorTypesAccordion">
+                            <div class="accordion-body">
+                                <div class="operator-list">
                 `;
 
-                top10.forEach((op, index) => {
+                operators.forEach(op => {
                     html += `
                         <div class="operator-list-item">
-                            <div>
-                                <strong>${index + 1}. ${op.operator}</strong>
-                                <span class="badge bg-light text-dark ms-2">${op.type}</span>
-                            </div>
-                            <span class="badge bg-warning text-dark">${op.occurrences} occurrences</span>
+                            <strong>${op.operator}</strong>
+                            <span class="badge bg-light text-dark">${op.occurrences} occurrences</span>
                         </div>
                     `;
                 });
 
                 html += `
-                        </div>
-                    </div>
-                    <hr>
-                    <h6 class="mb-3">All Missing Operators by Type</h6>
-                    <div class="accordion" id="operatorTypesAccordion">
-                `;
-
-                const sortedTypes = Object.keys(response.missing_operators_by_type).sort((a, b) => {
-                    const aTotal = response.missing_operators_by_type[a].reduce((sum, op) => sum + op.occurrences, 0);
-                    const bTotal = response.missing_operators_by_type[b].reduce((sum, op) => sum + op.occurrences, 0);
-                    return bTotal - aTotal;
-                });
-
-                sortedTypes.forEach((type, index) => {
-                    const operators = response.missing_operators_by_type[type];
-                    const totalOccurrences = operators.reduce((sum, op) => sum + op.occurrences, 0);
-                    const isFirst = index === 0;
-                    
-                    html += `
-                        <div class="accordion-item">
-                            <h2 class="accordion-header" id="heading-${type}">
-                                <button class="accordion-button ${isFirst ? '' : 'collapsed'}" type="button" 
-                                        data-bs-toggle="collapse" data-bs-target="#collapse-${type}" 
-                                        aria-expanded="${isFirst ? 'true' : 'false'}" aria-controls="collapse-${type}">
-                                    <strong class="text-capitalize">${type}</strong>
-                                    <span class="ms-auto me-3">
-                                        <span class="badge bg-primary">${operators.length} operators</span>
-                                        <span class="badge bg-secondary">${totalOccurrences} occurrences</span>
-                                    </span>
-                                </button>
-                            </h2>
-                            <div id="collapse-${type}" class="accordion-collapse collapse ${isFirst ? 'show' : ''}" 
-                                 aria-labelledby="heading-${type}" data-bs-parent="#operatorTypesAccordion">
-                                <div class="accordion-body">
-                                    <div class="operator-list">
-                    `;
-
-                    operators.forEach(op => {
-                        html += `
-                            <div class="operator-list-item">
-                                <strong>${op.operator}</strong>
-                                <span class="badge bg-light text-dark">${op.occurrences} occurrences</span>
-                            </div>
-                        `;
-                    });
-
-                    html += `
-                                    </div>
                                 </div>
                             </div>
                         </div>
-                    `;
-                });
-
-                html += `
                     </div>
                 `;
+            });
 
-                $('#missingOperatorsContent').html(html);
-            },
-            error: function(error) {
-                $('#missingOperatorsContent').html(`
-                    <div class="alert alert-danger" role="alert">
-                        <h4 class="alert-heading">Error</h4>
-                        <p>Failed to load missing operators: ${error.responseJSON?.message || 'Unknown error'}</p>
-                    </div>
-                `);
-            }
-        });
+            html += `
+                </div>
+            `;
+
+            $('#missingOperatorsContent').html(html);
+        }).catch((err) => {
+            $('#missingOperatorsContent').html(`
+                <div class="alert alert-danger" role="alert">
+                    <h4 class="alert-heading">Error</h4>
+                    <p>Failed to load missing operators: ${error.responseJSON?.message || 'Unknown error'}</p>
+                </div>
+            `);
+        })
     }
 
-    function updateOperator(uid, field, value) {
-        $.ajax({
-            type: 'POST',
-            url: '/admin/operators/update',
-            data: {
-                uid: uid,
-                field: field,
-                value: value.replace(/\s+/g, ' ').trim()
-            },
-            success: function(response) {
-                console.log('Operator updated');
-            },
-            error: function(error) {
-                console.log('Error:', error);
+    function updateOperator(operator_id, field, value) {
+        fetch(`/api/admin/operators/${operator_id}/${field}`, {
+            method: 'PUT',
+            body: value.trim(),
+            headers: {
+                'Content-Type': 'plain/text'
             }
-        });
+        }).then((res) => {
+            if(res.status > 299) {
+                res.text().then((err) => { throw new Error(err) });
+                return;
+            }
+            switch(field) {
+                case "short_name": bootstrapToast(`Short name for operator ${operator_id} updated successfully`); return;
+                case "long_name": bootstrapToast(`Long name for operator ${operator_id} updated successfully`); return;
+                case "operator_type": bootstrapToast(`Type for operator ${operator_id} updated successfully`); return;
+            }
+        }).catch((err) => console.log(`Error: ${err}`))
     }
 
-    function showLogoCarousel(uid) {
+    function showLogoCarousel(operator_id) {
         // Fetch all logos for the given operator
-        currentUid = uid;
-        $.ajax({
-            type: 'GET',
-            url: `/admin/operators/${uid}/logos`,  // API to fetch operator logos
-            success: function(response) {
+        currentUid = operator_id;
+        fetch(`/api/admin/operators/${operator_id}/logos`)
+            .catch(err => { alert(`Error: ${err}`)})
+            .then(res => res.json())
+            .then(response => {
                 const carouselInner = $('#carousel-images');
                 carouselInner.empty();  // Clear the previous images
 
@@ -546,7 +540,7 @@ let currentUid = null;
                     const isActive = index === 0 ? 'active' : '';
                     const effectiveDate = logo.effective_date ? new Date(logo.effective_date).toLocaleDateString() : 'None';
                     carouselInner.append(`
-                        <div class="carousel-item ${isActive}" data-logo-id="${logo.uid}">
+                        <div class="carousel-item ${isActive}" data-logo-id="${logo.operator_id}">
                             <img src="/static/${logo.logo_url}" class="d-block w-75" alt="Logo ${index}">
                             <div class="carousel-caption d-none d-md-block">
                                 <div class="d-flex justify-content-between align-items-center">
@@ -560,14 +554,11 @@ let currentUid = null;
 
                 // Show the modal with the carousel
                 $('#logoCarouselModal').modal('show');
-            },
-            error: function(error) {
-                alert('Error: ' + error.responseJSON.message);
-            }
-        });
+            })
     }
 
-    $('#uploadLogoForm').on('submit', function(e) {
+    const uploadLogoForm = document.getElementById('uploadLogoForm')
+    uploadLogoForm.addEventListener('submit', (e) => {
         e.preventDefault();
 
         const fileInput = document.getElementById('logoFile');
@@ -575,38 +566,36 @@ let currentUid = null;
 
         const formData = new FormData();
         formData.append('logo', fileInput.files[0]);
-        formData.append('uid', currentUid);  // Use the current UID
         formData.append('effective_date', effectiveDate);
 
-        $.ajax({
-            type: 'POST',
-            url: '/admin/operators/upload-logo',  // URL to handle logo upload
-            data: formData,
-            contentType: false,
-            processData: false,
-            success: function(response) {
-                location.reload();  // Reload to see updated logo
-            },
-            error: function(error) {
-                alert('Error: ' + error.responseJSON.message);
+        fetch(`/api/admin/operators/${currentUid}/logos`, {
+            method: 'POST',
+            body: formData
+        }).catch(err => { alert(`Error: ${err}`)}).then((res) => {
+            if(res.status > 299) {
+                res.text().then(err => {throw new Error(err)});
+                return;
             }
-        });
+
+            table.ajax.reload();
+            $('#logoCarouselModal').modal('hide')
+            bootstrapToast('Logo added successfully.')
+        })
     });
 
-    function deleteOperator(uid) {
-        if (confirm('Are you sure you want to delete this operator?')) {
-            $.ajax({
-                type: 'POST',
-                url: '/admin/operators/delete',
-                data: { uid: uid },
-                success: function(response) {
-                    location.reload();  // Reload to remove the operator
-                },
-                error: function(error) {
-                    alert('Error: ' + error.responseJSON.message);
+    function deleteOperator(operator_id) {
+        if (!confirm('Are you sure you want to delete this operator?')) return;
+
+        fetch(`/api/admin/operators/${operator_id}`, { method: 'DELETE' })
+            .then((res) => {
+                if(res.status > 299) {
+                    res.text().then(err => { throw new Error(err) });
+                    return
                 }
-            });
-        }
+                table.ajax.reload();
+                bootstrapToast(`Operator ${operator_id} deleted successfully.`)
+            })
+            .catch((err) => alert(`error: ${err}`))
     }
 
     function clearForm() {
@@ -614,25 +603,46 @@ let currentUid = null;
     }
 
     function deleteLogo(logoId) {
-        if (confirm('Are you sure you want to delete this logo?')) {
-            $.ajax({
-                type: 'POST',
-                url: '/admin/operators/delete-logo',  // URL to handle logo deletion
-                data: { logo_id: logoId },
-                success: function(response) {
-                    location.reload();  // Reload to see the updated logo list
-                },
-                error: function(error) {
-                    alert('Error: ' + error.responseJSON.message);
+        if (!confirm('Are you sure you want to delete this logo?')) return;
+
+        fetch(`/api/admin/operators/logos/${logoId}`, { method: 'DELETE'})
+            .then((res) => {
+                if(res.status > 299) {
+                    res.text().then(err => {throw new Error(err)});
+                    return;
                 }
-            });
-        }
+                table.ajax.reload();
+                $('#logoCarouselModal').modal('hide')
+                bootstrapToast('Logo deleted successfully.')
+            })
+            .catch(err => alert(`Error: ${err}`))
     }
 
     $('#logoCarouselModal').on('show.bs.modal', function () {
         $('#logoFile').val('');
         $('#effectiveDate').val('');
     });
+
+    /* Bootstrap toast helper */
+function bootstrapToast(message, type='success') {
+  const id = 'toast-' + Math.random().toString(36).slice(2);
+  const $toast = $(`
+    <div id="${id}" class="toast align-items-center bg-${type} text-white border-0 position-fixed bottom-0 end-0 m-3" role="alert" aria-live="assertive" aria-atomic="true">
+      <div class="d-flex">
+        <div class="toast-body">${message}</div>
+        <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+      </div>
+    </div>
+  `);
+  $('body').append($toast);
+  try {
+    const toast = new bootstrap.Toast($toast[0], { delay: 3000 });
+    toast.show();
+    $toast.on('hidden.bs.toast', () => $toast.remove());
+  } catch(e) {
+    setTimeout(() => $toast.remove(), 3000);
+  }
+}
 </script>
 
 {% endblock %}

--- a/templates/admin/operators.html
+++ b/templates/admin/operators.html
@@ -508,7 +508,7 @@
     function updateOperator(operator_id, field, value) {
         fetch(`/api/admin/operators/${operator_id}/${field}`, {
             method: 'PUT',
-            body: value.trim(),
+            body: value.replace(/\s+/g, ' ').trim(),
             headers: {
                 'Content-Type': 'plain/text'
             }


### PR DESCRIPTION
This PR introduces new `operators` and `operator_logos` tables in Postgres and a migration script to sync the operator data from SQLite to Postgres. This is a logical next step as the logos are needed by the trip reading queries.

To sync just the operator data (including the logos), the following command may be used:
`env $(cat .env | xargs) POSTGRES_HOST=localhost python3 -c "import logging; logging.basicConfig(level=logging.DEBUG); from src.db_sync import sync_operators_from_sqlite; sync_operators_from_sqlite()"`
However, syncing the full DB will also sync the operator data.

I've also done some housekeeping by introducing a new API blueprint for all actions related to the admin panel for operator management, and I've moved the relevant endpoints from `app.py` to `src/api/admin/operators.py`.
These new APIs will read from PG, and write modifications to both SQLite and PG, as individual trips are currently still being read from the SQLite database.

Finally, I've also modified the frontend code in `templates/admin/operators.html` to use the new endpoints. The data table is now also fetched over Ajax, and instead of reloading the page after each action, the table is refreshed instead.
All actions that modify data now also spawn a toast to indicate success.

<img width="1546" height="587" alt="image" src="https://github.com/user-attachments/assets/2e9be0dc-05cf-4004-bdb3-0e52f593201c" />
<img width="433" height="88" alt="image" src="https://github.com/user-attachments/assets/0162d73a-edfc-43f3-a29d-f9d2257e7b92" />
<img width="429" height="81" alt="image" src="https://github.com/user-attachments/assets/ff6f29c8-8c17-4458-a2af-beb92352d775" />
<img width="464" height="90" alt="image" src="https://github.com/user-attachments/assets/0bb1a3b7-8e7b-40ed-9688-d58a25ceb333" />
