### PR TITLE
In trip search always show all tags, including non-matching ones

### DIFF
--- a/sql/getDynamicUserTrips.sql
+++ b/sql/getDynamicUserTrips.sql
@@ -50,7 +50,13 @@ FilteredTrips AS (
     FROM Subquery
     LEFT JOIN airliners ON Subquery.material_type = airliners.iata
     LEFT JOIN tags_associations ON Subquery.uid = tags_associations.trip_id
-    LEFT JOIN tags ON tag_id = tags.uid
+    LEFT JOIN tags ON tags_associations.tag_id = tags.uid
+    LEFT JOIN tags_associations filtered_tags_associations ON Subquery.uid = filtered_tags_associations.trip_id
+    LEFT JOIN (
+        SELECT *
+        FROM tags
+        WHERE remove_diacritics(LOWER(tags.name)) LIKE remove_diacritics(LOWER(:search))
+    ) filtered_tags ON filtered_tags_associations.tag_id = filtered_tags.uid
     WHERE Subquery.username = :username
       AND past = :past
       AND (
@@ -68,8 +74,8 @@ FilteredTrips AS (
           remove_diacritics(LOWER(COALESCE(material_type_advanced, ''))) LIKE remove_diacritics(LOWER(:search)) OR
           remove_diacritics(LOWER(airliners.iata)) LIKE remove_diacritics(LOWER(:search)) OR 
           remove_diacritics(LOWER(airliners.manufacturer)) LIKE remove_diacritics(LOWER(:search)) OR 
-          remove_diacritics(LOWER(airliners.model)) LIKE remove_diacritics(LOWER(:search)) OR 
-          remove_diacritics(LOWER(tags.name)) LIKE remove_diacritics(LOWER(:search))
+          remove_diacritics(LOWER(airliners.model)) LIKE remove_diacritics(LOWER(:search)) OR
+          filtered_tags.uid IS NOT NULL
       )
     GROUP BY Subquery.uid
 )


### PR DESCRIPTION
I have some tags that include a city name, e.g. "Cologne Stadtbahn". When I now type "Cologne" in the search bar, the result contains a bunch of trips with that tag name, and a bunch of train trips going to Cologne Central Station and Cologne Trade Fair/Deutz.
However, due to the way the current filter works, I don't see any further tags of the above trips that have that one matching tag. Indeed, the only tags shown are those that match the search "Cologne" (at least ion the cases where the search query does not additionally match the dep or arr station).

This PR changes it to the following:

- a trip is shown if some of its data or one of its tags matches the search query (no changes to current behavior)
- for every shown trip, all of its tags are displayed (<- the change)

Real life example of this from prod: The trip https://trainlog.me/public/trip/539604 has two tags ("full run" and the voyage of that day which is named "[...] Cologne Diversions"). If I just search for "Cologne" in my trip list, this trip shows up, but I cannot see the "full run" tag.

ping @simfr24 