### PR TITLE
Add translations to more tables

### DIFF
--- a/templates/admin/admin.html
+++ b/templates/admin/admin.html
@@ -288,6 +288,23 @@
                 target: 0
             }
         },
+        language: {
+            info: "{{dtInfo}}",
+            paginate: {
+                next: "{{dtNext}}",
+                previous: "{{dtPrevious}}",
+            },
+            emptyTable: "{{dtEmptyTable}}",
+            select: {
+                rows: {
+                    "_": "{{dtMultipleLineSelected}}",
+                    "0": "",
+                    "1": "{{dtOneLineSelected}}"
+                },
+            },
+            lengthMenu: "{{dtLengthMenu}}",
+            search: "{{dtSearch}}"
+        },
         drawCallback: function() {
             resetObjects();
         },

--- a/templates/admin/airliners.html
+++ b/templates/admin/airliners.html
@@ -68,7 +68,24 @@
 <script>
     $(document).ready(function() {
         $('#airlinerTable').DataTable({
-            responsive:true
+            responsive:true,
+            language: {
+                info: "{{dtInfo}}",
+                paginate: {
+                    next: "{{dtNext}}",
+                    previous: "{{dtPrevious}}",
+                },
+                emptyTable: "{{dtEmptyTable}}",
+                select: {
+                    rows: {
+                        "_": "{{dtMultipleLineSelected}}",
+                        "0": "",
+                        "1": "{{dtOneLineSelected}}"
+                    },
+                },
+                lengthMenu: "{{dtLengthMenu}}",
+                search: "{{dtSearch}}"
+            },
         });
 
         $('#airlinerForm').on('submit', function(e) {

--- a/templates/admin/operators.html
+++ b/templates/admin/operators.html
@@ -329,7 +329,24 @@
         ],
         order: [
             [1, 'asc']
-        ]
+        ],
+        language: {
+            info: "{{dtInfo}}",
+            paginate: {
+                next: "{{dtNext}}",
+                previous: "{{dtPrevious}}",
+            },
+            emptyTable: "{{dtEmptyTable}}",
+            select: {
+                rows: {
+                    "_": "{{dtMultipleLineSelected}}",
+                    "0": "",
+                    "1": "{{dtOneLineSelected}}"
+                },
+            },
+            lengthMenu: "{{dtLengthMenu}}",
+            search: "{{dtSearch}}"
+        },
     });
 
     const operatorForm = document.getElementById('operatorForm');

--- a/templates/admin/ships.html
+++ b/templates/admin/ships.html
@@ -66,7 +66,24 @@
 <script>
     $(document).ready(function() {
         $('#shipTable').DataTable({
-            responsive: true
+            responsive: true,
+            language: {
+                info: "{{dtInfo}}",
+                paginate: {
+                    next: "{{dtNext}}",
+                    previous: "{{dtPrevious}}",
+                },
+                emptyTable: "{{dtEmptyTable}}",
+                select: {
+                    rows: {
+                        "_": "{{dtMultipleLineSelected}}",
+                        "0": "",
+                        "1": "{{dtOneLineSelected}}"
+                    },
+                },
+                lengthMenu: "{{dtLengthMenu}}",
+                search: "{{dtSearch}}"
+            },
         });
 
         $('#shipForm').on('submit', function(e) {

--- a/templates/admin/stations.html
+++ b/templates/admin/stations.html
@@ -64,6 +64,23 @@
         drawCallback: function(settings) {
             $('[data-toggle="tooltip"]').tooltip();
         },
+        language: {
+            info: "{{dtInfo}}",
+            paginate: {
+                next: "{{dtNext}}",
+                previous: "{{dtPrevious}}",
+            },
+            emptyTable: "{{dtEmptyTable}}",
+            select: {
+                rows: {
+                    "_": "{{dtMultipleLineSelected}}",
+                    "0": "",
+                    "1": "{{dtOneLineSelected}}"
+                },
+            },
+            lengthMenu: "{{dtLengthMenu}}",
+            search: "{{dtSearch}}"
+        },
     });
 </script>
 

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -106,7 +106,24 @@ $.get('{{url_for("getLeaderboardUsers", type=type)}}', function(users, status){
                 target: 0
             }
         },
-        order: [[4, 'desc']]  // Order by Total Trips in descending order
+        order: [[4, 'desc']],  // Order by Total Trips in descending order
+        language: {
+            info: "{{dtInfo}}",
+            paginate: {
+                next: "{{dtNext}}",
+                previous: "{{dtPrevious}}",
+            },
+            emptyTable: "{{dtEmptyTable}}",
+            select: {
+                rows: {
+                    "_": "{{dtMultipleLineSelected}}",
+                    "0": "",
+                    "1": "{{dtOneLineSelected}}"
+                },
+            },
+            lengthMenu: "{{dtLengthMenu}}",
+            search: "{{dtSearch}}"
+        },
     });
 
     dTable

--- a/templates/leaderboard_countries.html
+++ b/templates/leaderboard_countries.html
@@ -102,7 +102,24 @@ $.get('{{url_for("getLeaderboardUsers", type="country_count")}}', function(count
             }
         ],
         responsive: true,
-        order: [[2, 'desc']]  // Order by country count in descending order
+        order: [[2, 'desc']],  // Order by country count in descending order
+        language: {
+            info: "{{dtInfo}}",
+            paginate: {
+                next: "{{dtNext}}",
+                previous: "{{dtPrevious}}",
+            },
+            emptyTable: "{{dtEmptyTable}}",
+            select: {
+                rows: {
+                    "_": "{{dtMultipleLineSelected}}",
+                    "0": "",
+                    "1": "{{dtOneLineSelected}}"
+                },
+            },
+            lengthMenu: "{{dtLengthMenu}}",
+            search: "{{dtSearch}}"
+        },
     }).on( 'responsive-display', function ( e, datatable, row, showHide, update ) {
         $('[data-toggle="tooltip"]').tooltip();
     }).on( 'draw.dt',   function () {

--- a/templates/leaderboard_train_countries.html
+++ b/templates/leaderboard_train_countries.html
@@ -174,7 +174,24 @@ $.get('{{url_for("getLeaderboardUsers", type=type)}}', function(countries, statu
                 }
             }
         },
-        order: [[3, 'desc']]  // Order by percent in descending order
+        order: [[3, 'desc']],  // Order by percent in descending order
+        language: {
+            info: "{{dtInfo}}",
+            paginate: {
+                next: "{{dtNext}}",
+                previous: "{{dtPrevious}}",
+            },
+            emptyTable: "{{dtEmptyTable}}",
+            select: {
+                rows: {
+                    "_": "{{dtMultipleLineSelected}}",
+                    "0": "",
+                    "1": "{{dtOneLineSelected}}"
+                },
+            },
+            lengthMenu: "{{dtLengthMenu}}",
+            search: "{{dtSearch}}"
+        },
     });
 
     dTable.rows().every(function() {

--- a/templates/leaderboard_world_squares.html
+++ b/templates/leaderboard_world_squares.html
@@ -88,7 +88,24 @@ $.get('{{url_for("getLeaderboardUsers", type=type)}}', function(countries, statu
             }
         ],
         responsive: true,
-        order: [[2, 'desc']]  // Order by percent in descending order
+        order: [[2, 'desc']],  // Order by percent in descending order
+        language: {
+            info: "{{dtInfo}}",
+            paginate: {
+                next: "{{dtNext}}",
+                previous: "{{dtPrevious}}",
+            },
+            emptyTable: "{{dtEmptyTable}}",
+            select: {
+                rows: {
+                    "_": "{{dtMultipleLineSelected}}",
+                    "0": "",
+                    "1": "{{dtOneLineSelected}}"
+                },
+            },
+            lengthMenu: "{{dtLengthMenu}}",
+            search: "{{dtSearch}}"
+        },
     });
         hideLoading();
 }).fail(function() {

--- a/templates/list_gpx.html
+++ b/templates/list_gpx.html
@@ -264,7 +264,24 @@
       order: [],
       responsive: true,
       paging: false,
-      lengthMenu: [[10, 50, 100, -1], [10, 50, 100, "All"]]
+      lengthMenu: [[10, 50, 100, -1], [10, 50, 100, "All"]],
+      language: {
+        info: "{{dtInfo}}",
+        paginate: {
+            next: "{{dtNext}}",
+            previous: "{{dtPrevious}}",
+        },
+        emptyTable: "{{dtEmptyTable}}",
+        select: {
+            rows: {
+                "_": "{{dtMultipleLineSelected}}",
+                "0": "",
+                "1": "{{dtOneLineSelected}}"
+            },
+        },
+        lengthMenu: "{{dtLengthMenu}}",
+        search: "{{dtSearch}}"
+      },
     });
 
     // Sync modal toggle with main toggle

--- a/templates/ticket_list.html
+++ b/templates/ticket_list.html
@@ -238,7 +238,24 @@ $(document).ready(function () {
                         false;
                 }
             }
-        }
+        },
+        language: {
+            info: "{{dtInfo}}",
+            paginate: {
+                next: "{{dtNext}}",
+                previous: "{{dtPrevious}}",
+            },
+            emptyTable: "{{dtEmptyTable}}",
+            select: {
+                rows: {
+                    "_": "{{dtMultipleLineSelected}}",
+                    "0": "",
+                    "1": "{{dtOneLineSelected}}"
+                },
+            },
+            lengthMenu: "{{dtLengthMenu}}",
+            search: "{{dtSearch}}"
+        },
     });
 
     /* NEW: button toggles filter and redraws */


### PR DESCRIPTION
This is a part of https://github.com/BorealBaguette/Trainlog/pull/30, but can be merged separately.

For a bunch of tables, the surrounding elements like "previous" and "next" buttons are not translated. This PR just copies the block that is used for the trip table to all the other tables.