### PR TITLE
In the trip table, show delays of zero (again)

### DIFF
--- a/templates/dynamic_trips.html
+++ b/templates/dynamic_trips.html
@@ -1001,20 +1001,14 @@ function addSecsToDisplayTime(timeStr, secs) {
 
 function renderStartTime(data, type, row) {
     if (type === 'display') {
-        if (row.departure_delay) {
-            return data + renderDelayBadge(row.departure_delay);
-        }
-        return data;
+        return data + renderDelayBadge(row.departure_delay);
     }
     return data;
 }
 
 function renderEndTime(data, type, row) {
     if (type === 'display') {
-        if (row.arrival_delay) {
-            return data + renderDelayBadge(row.arrival_delay);
-        }
-        return data;
+        return data + renderDelayBadge(row.arrival_delay);
     }
     return data;
 }


### PR DESCRIPTION
The function `renderDelayBadge` already takes care of distinguishing the absence of a delay value from the value 0.

This resolves the issue pointed out at https://discord.com/channels/1155959833535713412/1156264583527407626/1478698511036973056.