### PR TITLE
Fix various date formattings that lose timezone info

### DIFF
--- a/static/js/util.js
+++ b/static/js/util.js
@@ -1190,3 +1190,8 @@ function showLoading() {
 function hideLoading() {
     document.getElementById('loadingScreen').style.display = 'none';
 }
+
+// date.toISOString() returns the date in UTC, we want to return it in local time but in the same format
+Date.prototype.toTimezonedISOString = function() {
+  return new Date(this.getTime() - (this.getTimezoneOffset() * 60000)).toISOString()
+}

--- a/templates/edit_copy.html
+++ b/templates/edit_copy.html
@@ -1277,11 +1277,11 @@
                 document.getElementById('radioPreciseDates').checked = true;
 
                 // Fill start date and time
-                document.getElementById('newTripStartDate').value = takeoffDate.toISOString().slice(0, 10);
+                document.getElementById('newTripStartDate').value = takeoffDate.toTimezonedISOString().slice(0, 10);
                 document.getElementById('newTripStartTime').value = takeoffDate.toTimeString().slice(0, 5);
 
                 // Fill end date and time
-                document.getElementById('newTripEndDate').value = landedDate.toISOString().slice(0, 10);
+                document.getElementById('newTripEndDate').value = landedDate.toTimezonedISOString().slice(0, 10);
                 document.getElementById('newTripEndTime').value = landedDate.toTimeString().slice(0, 5);
 
                 // Calculate and fill trip duration (following air routing pattern)
@@ -1576,8 +1576,8 @@
         var newEndDate = new Date(today);
         newEndDate.setDate(today.getDate() + dayDifference);
 
-        var formattedNewStartDate = newStartDate.toISOString().slice(0, 10);
-        var formattedNewEndDate = newEndDate.toISOString().slice(0, 10);
+        var formattedNewStartDate = newStartDate.toTimezonedISOString().slice(0, 10);
+        var formattedNewEndDate = newEndDate.toTimezonedISOString().slice(0, 10);
 
         $("#newTripStartDate").val(formattedNewStartDate);
         $("#newTripEndDate").val(formattedNewEndDate);
@@ -1678,7 +1678,7 @@
       var pt = document.getElementById(plannedTimeId).value;
       if (!pd || !pt) return;
       var actual = new Date(new Date(pd + 'T' + pt).getTime() + seconds * 1000);
-      document.getElementById(actualDateId).value = actual.toISOString().slice(0, 10);
+      document.getElementById(actualDateId).value = actual.toTimezonedISOString().slice(0, 10);
       document.getElementById(actualTimeId).value = actual.toTimeString().slice(0, 5);
     }
 

--- a/templates/new.html
+++ b/templates/new.html
@@ -482,7 +482,7 @@
       var pt = document.getElementById(plannedTimeId).value;
       if (!pd || !pt) return;
       var actual = new Date(new Date(pd + 'T' + pt).getTime() + seconds * 1000);
-      document.getElementById(actualDateId).value = actual.toISOString().slice(0, 10);
+      document.getElementById(actualDateId).value = actual.toTimezonedISOString().slice(0, 10);
       document.getElementById(actualTimeId).value = actual.toTimeString().slice(0, 5);
     }
 

--- a/templates/new_flight.html
+++ b/templates/new_flight.html
@@ -763,9 +763,9 @@ async function processFlightLeg(flight) {
     const startLocal = new Date(flight.datetime_takeoff_local);
     const endLocal = new Date(flight.datetime_landed_local);
     
-    $('#newTripStartDate').val(startLocal.toISOString().split('T')[0]);
+    $('#newTripStartDate').val(startLocal.toTimezonedISOString().split('T')[0]);
     $('#newTripStartTime').val(startLocal.toTimeString().slice(0, 5));
-    $('#newTripEndDate').val(endLocal.toISOString().split('T')[0]);
+    $('#newTripEndDate').val(endLocal.toTimezonedISOString().split('T')[0]);
     $('#newTripEndTime').val(endLocal.toTimeString().slice(0, 5));
     $('#radioPreciseDates').prop('checked', true);
   }
@@ -836,9 +836,9 @@ async function processFlightLegWithData(flight, processedData) {
 
   // Use pre-fetched local times (already parsed)
   if (processedData.departureLocal && processedData.arrivalLocal) {
-    $('#newTripStartDate').val(processedData.departureLocal.toISOString().split('T')[0]);
+    $('#newTripStartDate').val(processedData.departureLocal.toTimezonedISOString().split('T')[0]);
     $('#newTripStartTime').val(processedData.departureLocal.toTimeString().slice(0, 5));
-    $('#newTripEndDate').val(processedData.arrivalLocal.toISOString().split('T')[0]);
+    $('#newTripEndDate').val(processedData.arrivalLocal.toTimezonedISOString().split('T')[0]);
     $('#newTripEndTime').val(processedData.arrivalLocal.toTimeString().slice(0, 5));
     $('#radioPreciseDates').prop('checked', true);
   }
@@ -907,9 +907,9 @@ async function processFlightLegWithData(flight, processedData) {
 
   // Use pre-fetched local times
   if (processedData.departureLocal && processedData.arrivalLocal) {
-    $('#newTripStartDate').val(processedData.departureLocal.toISOString().split('T')[0]);
+    $('#newTripStartDate').val(processedData.departureLocal.toTimezonedISOString().split('T')[0]);
     $('#newTripStartTime').val(processedData.departureLocal.toTimeString().slice(0, 5));
-    $('#newTripEndDate').val(processedData.arrivalLocal.toISOString().split('T')[0]);
+    $('#newTripEndDate').val(processedData.arrivalLocal.toTimezonedISOString().split('T')[0]);
     $('#newTripEndTime').val(processedData.arrivalLocal.toTimeString().slice(0, 5));
     $('#radioPreciseDates').prop('checked', true);
   }

--- a/templates/public/new_trip.html
+++ b/templates/public/new_trip.html
@@ -544,8 +544,8 @@ function buildItinerary(trips, prices) {
                 trips[index + 1].trip.utc_filtered_start_datetime
             );
             actualChangeTime = changeTime + (trips[index + 1].trip.departure_delay || 0) - (trip.trip.arrival_delay || 0);
-            var previousDay = new Date(trip.trip.end_datetime).toISOString().slice(0, 10);
-            var currentDay = new Date(trip.trip.start_datetime).toISOString().slice(0, 10);
+            var previousDay = new Date(trip.trip.end_datetime).toTimezonedISOString().slice(0, 10);
+            var currentDay = new Date(trip.trip.start_datetime).toTimezonedISOString().slice(0, 10);
             if (currentDay != previousDay) {
                 dayChangeTrip = true;
             }
@@ -557,8 +557,8 @@ function buildItinerary(trips, prices) {
                 trip.trip.utc_filtered_start_datetime
             );
 
-            var previousDay = new Date(trips[index - 1].trip.end_datetime).toISOString().slice(0, 10);
-            var currentDay = new Date(trip.trip.start_datetime).toISOString().slice(0, 10);
+            var previousDay = new Date(trips[index - 1].trip.end_datetime).toTimezonedISOString().slice(0, 10);
+            var currentDay = new Date(trip.trip.start_datetime).toTimezonedISOString().slice(0, 10);
             if (currentDay != previousDay && precedingChangeTime <= 43200) {
                 dayChangeIntertrip = true;
             }

--- a/templates/public/public_trip.html
+++ b/templates/public/public_trip.html
@@ -301,8 +301,8 @@ if (prices.total_carbon != 0){
         trips[index + 1].trip.utc_filtered_start_datetime
       );
       actualChangeTime = changeTime + (trips[index + 1].trip.departure_delay || 0) - (trip.trip.arrival_delay || 0);
-      var previousDay = new Date(trip.trip.end_datetime).toISOString().slice(0, 10)
-      var currentDay = new Date(trip.trip.start_datetime).toISOString().slice(0, 10)
+      var previousDay = new Date(trip.trip.end_datetime).toTimezonedISOString().slice(0, 10)
+      var currentDay = new Date(trip.trip.start_datetime).toTimezonedISOString().slice(0, 10)
       if (currentDay != previousDay)
       {
         dayChangeTrip = true;
@@ -316,8 +316,8 @@ if (prices.total_carbon != 0){
         
       );
 
-      var previousDay = new Date(trips[index-1].trip.end_datetime).toISOString().slice(0, 10)
-      var currentDay = new Date(trip.trip.start_datetime).toISOString().slice(0, 10)
+      var previousDay = new Date(trips[index-1].trip.end_datetime).toTimezonedISOString().slice(0, 10)
+      var currentDay = new Date(trip.trip.start_datetime).toTimezonedISOString().slice(0, 10)
       if (currentDay != previousDay && precedingChangeTime <= 43200)
       {
         dayChangeIntertrip = true;


### PR DESCRIPTION
Fixes:
- switching between the two delay edit modes no longer jumps between dates (https://discord.com/channels/1155959833535713412/1156264583527407626/1479174510509822124)
- importing FR24 flights that have different dates in local time and UTC now correctly import the date of the local time
- copying a trip starting between midnight and 1am (in CET) now correctly inputs todays date (instead of yesterdays), if my local time also is between midnight and 1 am.
- weird things in the trip view like the duplicate date header here <img width="354" height="234" alt="2026-03-06_12-00" src="https://github.com/user-attachments/assets/3429b335-3b7a-48bf-943d-f8eaba8ed746" />
- and a few more similar things

I did not touch any of the undocumented or admin pages, as I have no idea what they actually should do and thus cannot reason if they need a similar fix.