### PR TITLE
Use delays when deciding `is_past`

### DIFF
--- a/sql/getCurrentTrip.sql
+++ b/sql/getCurrentTrip.sql
@@ -1,19 +1,23 @@
 WITH UTC_Filtered AS (
     SELECT *, 
-    CASE
-        WHEN utc_start_datetime IS NOT NULL
-        THEN utc_start_datetime
-        ELSE start_datetime 
-    END AS 'utc_filtered_start_datetime',
-    CASE
-        WHEN utc_end_datetime IS NOT NULL
-        THEN utc_end_datetime
-        ELSE end_datetime 
-    END AS 'utc_filtered_end_datetime'
+        COALESCE(
+            datetime(
+                utc_start_datetime,
+                printf('%+d seconds', COALESCE(departure_delay, 0))
+            ),
+            start_datetime
+        ) AS actual_start_datetime,
+        COALESCE(
+            datetime(
+                utc_end_datetime,
+                printf('%+d seconds', COALESCE(arrival_delay, 0))
+            ),
+            end_datetime
+        ) AS actual_end_datetime
     FROM trip
 )
 
 SELECT uid
 FROM UTC_Filtered 
 WHERE username == :username
-AND julianday('now') BETWEEN  julianday(utc_filtered_start_datetime) AND julianday(utc_filtered_end_datetime)
+AND julianday('now') BETWEEN julianday(actual_start_datetime) AND julianday(actual_end_datetime)

--- a/sql/getDynamicUserTrips.sql
+++ b/sql/getDynamicUserTrips.sql
@@ -1,7 +1,21 @@
 WITH UTC_Filtered AS (
     SELECT *,
         COALESCE(utc_start_datetime, start_datetime) AS utc_filtered_start_datetime,
-        COALESCE(utc_end_datetime, end_datetime) AS utc_filtered_end_datetime
+        COALESCE(utc_end_datetime, end_datetime) AS utc_filtered_end_datetime,
+        COALESCE(
+            datetime(
+                utc_start_datetime,
+                printf('%+d seconds', COALESCE(departure_delay, 0))
+            ),
+            start_datetime
+        ) AS actual_start_datetime,
+        COALESCE(
+            datetime(
+                utc_end_datetime,
+                printf('%+d seconds', COALESCE(arrival_delay, 0))
+            ),
+            end_datetime
+        ) AS actual_end_datetime
     FROM trip
 ),
 Subquery AS (
@@ -30,13 +44,13 @@ FilteredTrips AS (
     SELECT Subquery.*, airliners.*,
            trip_length / trip_duration_seconds AS trip_speed,
            CASE
-               WHEN (julianday('now') > julianday(utc_filtered_start_datetime) 
+               WHEN (julianday('now') > julianday(actual_start_datetime) 
                      OR utc_filtered_start_datetime = -1)
                     AND utc_filtered_start_datetime != 1 THEN 1
                ELSE 0
            END AS 'past',
            CASE
-               WHEN julianday('now') <= julianday(utc_filtered_start_datetime) THEN 1
+               WHEN julianday('now') <= julianday(actual_start_datetime) THEN 1
                ELSE 0
            END AS 'plannedFuture',
            CASE

--- a/sql/getTrip.sql
+++ b/sql/getTrip.sql
@@ -1,28 +1,34 @@
 WITH UTC_Filtered AS (
     SELECT *, 
-    CASE
-        WHEN utc_start_datetime IS NOT NULL
-        THEN utc_start_datetime
-        ELSE start_datetime 
-    END AS 'utc_filtered_start_datetime',
-    CASE
-        WHEN utc_end_datetime IS NOT NULL
-        THEN utc_end_datetime
-        ELSE end_datetime 
-    END AS 'utc_filtered_end_datetime'
+        COALESCE(utc_start_datetime, start_datetime) AS utc_filtered_start_datetime,
+        COALESCE(utc_end_datetime, end_datetime) AS utc_filtered_end_datetime,
+        COALESCE(
+            datetime(
+                utc_start_datetime,
+                printf('%+d seconds', COALESCE(departure_delay, 0))
+            ),
+            start_datetime
+        ) AS actual_start_datetime,
+        COALESCE(
+            datetime(
+                utc_end_datetime,
+                printf('%+d seconds', COALESCE(arrival_delay, 0))
+            ),
+            end_datetime
+        ) AS actual_end_datetime
     FROM trip
 )
 
 SELECT 
     t.*,
     CASE
-        WHEN julianday('now') > julianday(utc_filtered_end_datetime) 
+        WHEN julianday('now') > julianday(actual_end_datetime) 
             OR utc_filtered_start_datetime = -1
             AND utc_filtered_start_datetime != 1
         THEN 'past'
-        WHEN julianday('now') <= julianday(utc_filtered_start_datetime)
+        WHEN julianday('now') <= julianday(actual_start_datetime)
         THEN 'plannedFuture'
-        WHEN julianday('now') BETWEEN  julianday(utc_filtered_start_datetime) AND julianday(utc_filtered_end_datetime)
+        WHEN julianday('now') BETWEEN  julianday(actual_start_datetime) AND julianday(actual_end_datetime)
         THEN 'current'
         WHEN utc_filtered_start_datetime = 1
         THEN 'future'

--- a/sql/getTripsCountry.sql
+++ b/sql/getTripsCountry.sql
@@ -1,10 +1,13 @@
 WITH UTC_Filtered AS (
     SELECT *, 
-    CASE
-        WHEN utc_start_datetime IS NOT NULL
-        THEN utc_start_datetime
-        ELSE start_datetime 
-    END AS 'utc_filtered_start_datetime'
+        COALESCE(utc_start_datetime, start_datetime) AS utc_filtered_start_datetime,
+        COALESCE(
+            datetime(
+                utc_start_datetime,
+                printf('%+d seconds', COALESCE(departure_delay, 0))
+            ),
+            start_datetime
+        ) AS actual_start_datetime
     FROM trip
 )
 
@@ -12,7 +15,7 @@ SELECT *,
 CASE
 	WHEN  
 		(
-			julianday('now') > julianday(utc_filtered_start_datetime) 
+			julianday('now') > julianday(actual_start_datetime) 
 			OR utc_filtered_start_datetime = -1
 		)
 		AND utc_filtered_start_datetime != 1
@@ -20,7 +23,7 @@ CASE
 	ELSE 0
 END AS 'past',
 CASE
-	WHEN julianday('now') <= julianday(utc_filtered_start_datetime)
+	WHEN julianday('now') <= julianday(actual_start_datetime)
 	THEN 1
 	ELSE 0 
 END AS 'plannedFuture',

--- a/sql/getUniqueUserTrips.sql
+++ b/sql/getUniqueUserTrips.sql
@@ -1,13 +1,21 @@
 WITH UTC_Filtered AS (
     SELECT *,
-    CASE
-        WHEN utc_start_datetime IS NOT NULL THEN utc_start_datetime
-        ELSE start_datetime 
-    END AS utc_filtered_start_datetime,
-    CASE
-        WHEN utc_end_datetime IS NOT NULL THEN utc_end_datetime
-        ELSE end_datetime 
-    END AS utc_filtered_end_datetime
+        COALESCE(utc_start_datetime, start_datetime) AS utc_filtered_start_datetime,
+        COALESCE(utc_end_datetime, end_datetime) AS utc_filtered_end_datetime,
+        COALESCE(
+            datetime(
+                utc_start_datetime,
+                printf('%+d seconds', COALESCE(departure_delay, 0))
+            ),
+            start_datetime
+        ) AS actual_start_datetime,
+        COALESCE(
+            datetime(
+                utc_end_datetime,
+                printf('%+d seconds', COALESCE(arrival_delay, 0))
+            ),
+            end_datetime
+        ) AS actual_end_datetime
     FROM trip
 ),
 YearlyFiltered AS (
@@ -20,7 +28,7 @@ SELECT *,
        CASE
            WHEN  
                (
-                   julianday('now') > julianday(utc_filtered_end_datetime) 
+                   julianday('now') > julianday(actual_end_datetime) 
                    OR utc_filtered_start_datetime = -1
                )
                AND utc_filtered_start_datetime != 1
@@ -28,12 +36,12 @@ SELECT *,
            ELSE 0
        END AS past,
        CASE
-           WHEN julianday('now') BETWEEN julianday(utc_filtered_start_datetime) AND julianday(utc_filtered_end_datetime)
+           WHEN julianday('now') BETWEEN julianday(actual_start_datetime) AND julianday(actual_end_datetime)
            THEN 1
            ELSE 0 
        END AS current,
        CASE
-           WHEN julianday('now') <= julianday(utc_filtered_start_datetime)
+           WHEN julianday('now') <= julianday(actual_start_datetime)
            THEN 1
            ELSE 0 
        END AS plannedFuture,

--- a/sql/getUserTrips.sql
+++ b/sql/getUserTrips.sql
@@ -1,10 +1,13 @@
 WITH UTC_Filtered AS (
     SELECT *, 
-    CASE
-        WHEN utc_start_datetime IS NOT NULL
-        THEN utc_start_datetime
-        ELSE start_datetime 
-    END AS 'utc_filtered_start_datetime'
+        COALESCE(utc_start_datetime, start_datetime) AS utc_filtered_start_datetime,
+        COALESCE(
+            datetime(
+                utc_start_datetime,
+                printf('%+d seconds', COALESCE(departure_delay, 0))
+            ),
+            start_datetime
+        ) AS actual_start_datetime
     FROM trip
 )
 
@@ -12,7 +15,7 @@ SELECT *,
 CASE
 	WHEN  
 		(
-			julianday('now') > julianday(utc_filtered_start_datetime) 
+			julianday('now') > julianday(actual_start_datetime) 
 			OR utc_filtered_start_datetime = -1
 		)
 		AND utc_filtered_start_datetime != 1
@@ -20,7 +23,7 @@ CASE
 	ELSE 0
 END AS 'past',
 CASE
-	WHEN julianday('now') <= julianday(utc_filtered_start_datetime)
+	WHEN julianday('now') <= julianday(actual_start_datetime)
 	THEN 1
 	ELSE 0 
 END AS 'plannedFuture',

--- a/sql/stats/countriesLeaderboard.sql
+++ b/sql/stats/countriesLeaderboard.sql
@@ -1,22 +1,25 @@
 
 WITH UTC_Filtered AS (
 	SELECT *,
-		CASE
-			WHEN utc_start_datetime IS NOT NULL
-			THEN utc_start_datetime
-			ELSE start_datetime 
-		END AS utc_filtered_start_datetime
+        COALESCE(utc_start_datetime, start_datetime) AS utc_filtered_start_datetime,
+        COALESCE(
+            datetime(
+                utc_start_datetime,
+                printf('%+d seconds', COALESCE(departure_delay, 0))
+            ),
+            start_datetime
+        ) AS actual_start_datetime
 	FROM trip
 ), counted AS (SELECT *, 
 CASE
-	WHEN  (julianday('now') > julianday(utc_filtered_start_datetime) 
+	WHEN  (julianday('now') > julianday(actual_start_datetime) 
 	OR utc_filtered_start_datetime = -1)
 	AND utc_filtered_start_datetime != 1
 	THEN 1
 	ELSE 0
 END AS 'past',
 CASE
-	WHEN  julianday('now') <= julianday(utc_filtered_start_datetime)
+	WHEN  julianday('now') <= julianday(actual_start_datetime)
 	THEN 1
 	ELSE 0 
 END AS 'plannedFuture',

--- a/sql/stats/leaderboardStats.sql
+++ b/sql/stats/leaderboardStats.sql
@@ -2,24 +2,27 @@ WITH RECURSIVE
 
 UTC_Filtered AS (
 	SELECT *,
-		CASE
-			WHEN utc_start_datetime IS NOT NULL
-			THEN utc_start_datetime
-			ELSE start_datetime 
-		END AS utc_filtered_start_datetime
+        COALESCE(utc_start_datetime, start_datetime) AS utc_filtered_start_datetime,
+        COALESCE(
+            datetime(
+                utc_start_datetime,
+                printf('%+d seconds', COALESCE(departure_delay, 0))
+            ),
+            start_datetime
+        ) AS actual_start_datetime
 	FROM trip
 
 
 ), counted AS (SELECT *, 
 CASE
-	WHEN  (julianday('now') > julianday(utc_filtered_start_datetime) 
+	WHEN  (julianday('now') > julianday(actual_start_datetime) 
 	OR utc_filtered_start_datetime = -1)
 	AND utc_filtered_start_datetime != 1
 	THEN 1
 	ELSE 0
 END AS 'past',
 CASE
-	WHEN  julianday('now') <= julianday(utc_filtered_start_datetime)
+	WHEN  julianday('now') <= julianday(actual_start_datetime)
 	THEN 1
 	ELSE 0 
 END AS 'plannedFuture',

--- a/src/sql/leaderboards/countries_leaderboard.sql
+++ b/src/sql/leaderboards/countries_leaderboard.sql
@@ -1,24 +1,27 @@
 -- Get countries visited by each user for the leaderboard
 WITH utc_filtered AS (
     SELECT *,
-        CASE
-            WHEN utc_start_datetime IS NOT NULL
-            THEN utc_start_datetime
-            ELSE start_datetime 
-        END AS utc_filtered_start_datetime
+        COALESCE(
+            utc_start_datetime,
+            start_datetime
+        ) AS utc_filtered_start_datetime,
+        COALESCE(
+            utc_start_datetime + COALESCE(departure_delay, 0) * INTERVAL '1 second',
+            start_datetime
+        ) AS actual_start_datetime
     FROM trips
 ),
 counted AS (
     SELECT *, 
         CASE
-            WHEN (NOW() > utc_filtered_start_datetime 
+            WHEN (NOW() > actual_start_datetime 
                 OR utc_filtered_start_datetime IS NULL)
                 AND NOT is_project
             THEN 1
             ELSE 0
         END AS past,
         CASE
-            WHEN NOW() <= utc_filtered_start_datetime
+            WHEN NOW() <= actual_start_datetime
                 AND NOT is_project
             THEN 1
             ELSE 0 

--- a/src/sql/leaderboards/leaderboard_stats.sql
+++ b/src/sql/leaderboards/leaderboard_stats.sql
@@ -1,24 +1,27 @@
 -- Get leaderboard statistics grouped by user and trip trip_type
 WITH utc_filtered AS (
     SELECT *,
-        CASE
-            WHEN utc_start_datetime IS NOT NULL
-            THEN utc_start_datetime
-            ELSE start_datetime 
-        END AS utc_filtered_start_datetime
+        COALESCE(
+            utc_start_datetime,
+            start_datetime
+        ) AS utc_filtered_start_datetime,
+        COALESCE(
+            utc_start_datetime + COALESCE(departure_delay, 0) * INTERVAL '1 second',
+            start_datetime
+        ) AS actual_start_datetime
     FROM trips
 ),
 counted AS (
     SELECT *, 
         CASE
-            WHEN (NOW() > utc_filtered_start_datetime 
+            WHEN (NOW() > actual_start_datetime 
                 OR utc_filtered_start_datetime IS NULL)
                 AND NOT is_project
             THEN 1
             ELSE 0
         END AS past,
         CASE
-            WHEN NOW() <= utc_filtered_start_datetime
+            WHEN NOW() <= actual_start_datetime
                 AND NOT is_project
             THEN 1
             ELSE 0 

--- a/src/sql/stats/cte/base_filter.sql
+++ b/src/sql/stats/cte/base_filter.sql
@@ -1,6 +1,10 @@
 -- Base filtering CTE - filters trips by type, user, and year
 SELECT *,
-    COALESCE(utc_start_datetime, start_datetime) AS filtered_datetime
+    COALESCE(utc_start_datetime, start_datetime) AS filtered_datetime,
+    COALESCE(
+        utc_start_datetime + COALESCE(departure_delay, 0) * INTERVAL '1 second',
+        start_datetime
+    ) AS actual_datetime
 FROM trips
 WHERE trip_type = :tripType
 AND (:user_id IS NULL OR user_id = :user_id)

--- a/src/sql/stats/cte/time_categories.sql
+++ b/src/sql/stats/cte/time_categories.sql
@@ -1,14 +1,14 @@
 SELECT *,
 CASE
   WHEN is_project = false
-    AND (filtered_datetime IS NULL OR NOW() > filtered_datetime)
+    AND (filtered_datetime IS NULL OR NOW() > actual_datetime)
   THEN 1 ELSE 0
 END AS is_past,  -- both definite and indefinite past
 
 CASE
   WHEN is_project = false
     AND filtered_datetime IS NOT NULL
-    AND NOW() <= filtered_datetime
+    AND NOW() <= actual_datetime
   THEN 1 ELSE 0
 END AS is_planned_future,  -- definite future
 

--- a/src/sql/trips/get_current_trip.sql
+++ b/src/sql/trips/get_current_trip.sql
@@ -1,11 +1,17 @@
-WITH UTC_Filtered AS (
-    SELECT t.*,
-    COALESCE(t.utc_start_datetime, t.start_datetime) AS utc_filtered_start_datetime,
-    COALESCE(t.utc_end_datetime, t.end_datetime) AS utc_filtered_end_datetime
-    FROM trips t
+WITH utc_filtered AS (
+    SELECT *,
+        COALESCE(
+            utc_start_datetime + COALESCE(departure_delay, 0) * INTERVAL '1 second',
+            start_datetime
+        ) AS actual_start_datetime,
+        COALESCE(
+            utc_end_datetime + COALESCE(arrival_delay, 0) * INTERVAL '1 second',
+            end_datetime
+        ) AS actual_end_datetime
+    FROM trips
 )
 
 SELECT trip_id
-FROM UTC_Filtered
+FROM utc_filtered
 WHERE user_id = :user_id
-AND NOW() BETWEEN utc_filtered_start_datetime AND utc_filtered_end_datetime
+AND NOW() BETWEEN actual_start_datetime AND actual_end_datetime

--- a/static/js/util.js
+++ b/static/js/util.js
@@ -753,6 +753,13 @@ function computeTimeStatus(data) {
     let end = typeof trip.utc_filtered_end_datetime === 'string' ? moment.utc(trip.utc_filtered_end_datetime) : null;
     let now = moment.utc();  // Current UTC time
 
+    if (start && trip.departure_delay) {
+        start = start.add(trip.departure_delay, 'seconds');
+    }
+    if (end && trip.arrival_delay) {
+        end = end.add(trip.arrival_delay, 'seconds');
+    }
+
     if (start && end && now.isBetween(start, end, undefined, '[]')) {
         // Current date is between start and end (inclusive)
         data.time = 'current';


### PR DESCRIPTION
The sql files currently use a bunch of slightly different checks for that. I did not try to unify these at all, instead I just used actual times for all comparisons with "now", instead of scheduled times.

Unifiying these would make more sense after the trips table moved to postgres, as that has a bunch more datetime utilities that sqlite that then could be used there.