### PR TITLE
Avoid refitting live map on refresh

### DIFF
--- a/templates/public/current_global.html
+++ b/templates/public/current_global.html
@@ -324,6 +324,6 @@ function loadTrips(){
 }
 
 loadTrips();                        // first draw (fit happens after data arrives)
-setInterval(loadTrips, 60000);       // refresh every 5 seconds
+setInterval(loadTrips, 60000);       // refresh every 60 seconds
 </script>
 {% endblock %}


### PR DESCRIPTION
this is a bit annoying when you zoom in to have a closer look at some routing, and every 60 sec the zoom resets. This PR changes it to just update the drawn data, but not resetting the zoom status.