### PR TITLE
Fix CA-ON.geojson

### DIFF
--- a/country_percent/countries/processed/CA-ON.geojson
+++ b/country_percent/countries/processed/CA-ON.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c9a5fc21824bccaf496750bcfc19c156072f3878d9c8d14973d9087490d47275
-size 4764376
+oid sha256:cb6ee6ef240c715412bab74ce8f9b7e4626d56175ca278685be8bcbee8c8512a
+size 2302067


### PR DESCRIPTION
The new map from https://github.com/BorealBaguette/Trainlog/pull/144 has a slightly different crs, which means that the stitching code refuses to work.
This PR just runs `simplify_geojson.py` on that file, so every other change that does that e.g. to all files is also fine.