### PR TITLE
Re-add coverage map for IT-57 (Marche)

### DIFF
--- a/country_percent/countries/processed/IT-57.geojson
+++ b/country_percent/countries/processed/IT-57.geojson
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8f32faabf7a1078d26fa0cfd52f27388315b7a17bdc010d0b41f7d99f821977
+size 394588


### PR DESCRIPTION
This coverage map broke due to an unknown reason in https://github.com/BorealBaguette/Trainlog/commit/68552c2af91662b02a9a56ce8158a224d61ed629#diff-4ecb41a1597b7dc816f146b40a8377382008ab46c0a3501c58e4c28475bf30ef, and was then later removed in https://github.com/BorealBaguette/Trainlog/commit/79cbdd751a72b634815a4c31fc65c649155dfa4b.

By a request on discord, I recreated the IT-57 map by checking out https://github.com/BorealBaguette/Trainlog/commit/68552c2af91662b02a9a56ce8158a224d61ed629 and performing the relevant part of `sub.py` again.