### PR TITLE
fix: Simplify IE files to fix the Roscrea area

### DIFF
--- a/country_percent/countries/processed/IE-C.geojson
+++ b/country_percent/countries/processed/IE-C.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:dc50e3391c7dd0514cf35620d24b711e32092f6ddc7ecf1d9eff5566eb26691c
-size 410541
+oid sha256:2bf35b45063ee18aec34ffbeed2df1263d7849813f4e4bbf404fb463b7eec592
+size 216422

--- a/country_percent/countries/processed/IE-L.geojson
+++ b/country_percent/countries/processed/IE-L.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:421a1d8c140a53b78f52226bb4ca17be56d006cf913287d0e56ed15ab7808503
-size 532600
+oid sha256:ba9fce545217bbdf1e3c2576f7c06e28aa203b4c1d61126108921c1a749f565a
+size 314181

--- a/country_percent/countries/processed/IE-M.geojson
+++ b/country_percent/countries/processed/IE-M.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:44c77a3c27cb70fb09e6d8d9446f8d9a15a1eb0a55c5d571da13b126a3fbbf0e
-size 748292
+oid sha256:c2e4bb1a9424894014a3b01b5d7e7f4ceca7cd41011e757c169c00e00f458bdc
+size 186212


### PR DESCRIPTION
Using the improved script from https://github.com/BorealBaguette/Trainlog/pull/169.

Closes https://github.com/BorealBaguette/Trainlog/pull/165.