### PR TITLE
fix: clean up New Columbia (CA-BC) coverage file

### DIFF
--- a/country_percent/countries/processed/CA-BC.geojson
+++ b/country_percent/countries/processed/CA-BC.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:46a948acef97089d547d7835c141a470c8dc1ddaccefdc6cee0049ca3d221f15
-size 8203266
+oid sha256:6165558d65009c2e67b9eda7fc26fe54101615d147af2b78079c3580a5bde533
+size 2916723


### PR DESCRIPTION
note: the gap between Whistler and Pemberton is not a mistake. The _Rainforest to Gold Rush_ route from Rocky Mountaineer drops people in Whistler with an overnight stay in Whistler, and then buses them to Pemberton the next day to continue the trip from there, and vice versa. The train travels between Whistler and Pemberton without passengers on board.