### PR TITLE
fix: Make "all time" button active when loading page

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -610,8 +610,8 @@
     <!-- Year scope toggle — controls This Year, Highlights, Records -->
     <div class="d-flex justify-content-end dash-row" style="padding:0 4px; margin-bottom:-0.25rem;">
       <div class="rank-metric-toggle" id="hl-scope-toggle">
-        <button class="rank-metric-btn" data-scope="alltime">{{ allTime }}</button>
-        <select id="hl-year-select" class="hl-year-select rank-metric-btn active"></select>
+        <button class="rank-metric-btn active" data-scope="alltime">{{ allTime }}</button>
+        <select id="hl-year-select" class="hl-year-select rank-metric-btn"></select>
       </div>
     </div>
 


### PR DESCRIPTION
By default the dashboard all-time stats are shown while the button for the current year is highlighted. 
This change makes the all-time button highlighted after loading the page