### PR TITLE
fix: Show yearly leaderboard data instead of all time

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1420,7 +1420,7 @@ function fetchLeaderboard(year) {
   });
 }
 
-fetchLeaderboard(null);
+fetchLeaderboard(_hlYear);
 
 // ─── Friends ─────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
When loading the userdashboard, the 2026 data shown is for all stats except for the leaderboard. This change makes it so that the leaderboard also shows the 2026 data by default.