### PR TITLE
Make allowed hosts an entry in config.yaml

### DIFF
--- a/app.py
+++ b/app.py
@@ -945,22 +945,19 @@ def create_authDb():
 
 @app.before_request
 def before_request():
-    allowed_hosts = [
-        "127.0.0.1:5000",
-        "localhost:5000",
-        "trainlog.me",
-        "www.trainlog.me",
-        "dev.trainlog.me",
-    ]
-    if request.host not in allowed_hosts:
-        log_suspicious_activity(
-            request.url,
-            "invalid_host",
-            request.host,
-            getIp(request),
-            getRequestData(request),
-        )
-        return "", 406
+    if load_config()["allowed_hosts"]["addresses"] == "":
+        raise ValueError("Allowed hosts section in config.yaml empty")
+    else:
+        allowed_hosts = load_config()["allowed_hosts"]["addresses"]
+        if request.host not in allowed_hosts:
+            log_suspicious_activity(
+                request.url,
+                "invalid_host",
+                request.host,
+                getIp(request),
+                getRequestData(request),
+            )
+            return "", 406
     endpoint = request.endpoint
     if endpoint:
         # Get the URL rule associated with the current endpoint

--- a/config-example.yaml
+++ b/config-example.yaml
@@ -16,6 +16,14 @@ owner:
   email: your_email
   password: your_password
 
+# Allowed hosts in the HTTP request header
+allowed_hosts:
+  addresses: 
+    - 127.0.0.1:5000
+    - localhost:5000
+    - trainlog.me
+    - www.trainlog.me
+    - dev.trainlog.me
 
 # ================================
 # OPTIONAL CONFIGURATION


### PR DESCRIPTION
The allowed hosts in the request headers are currently defined in the function itself in app.py. When self-hosting for developing, you might want to add or change the host for your intended purpose. This can be done in the app.py file itself, but this change gets lost anytime you pull an update to app.py. This PR moves the hosts into the config.yaml file which means the changes don't get lost everytime app.py is updated.

Posting as draft because I'm not yet sure if this is the best way to do this, I would like some feedback on this