### PR TITLE
Redicrect from lowercase cc coverage to uppercase

### DIFF
--- a/app.py
+++ b/app.py
@@ -3491,10 +3491,15 @@ def countries(username, cc):
         public_url = url_for("countries", username=username, cc=cc)
         return redirect(public_url)
 
+    # to be removed eventually when all cc in db are uppercase, but added for safety as some old entries have lowercase cc
+    if cc != cc.upper():
+        return redirect(url_for("countries", username=username, cc=cc.upper()))
+
     if username == getUser():
         nav = "bootstrap/navigation.html"
     else:
         nav = "bootstrap/public_nav.html"
+
     if not has_coverage_file(cc):
         abort(410)
 

--- a/py/coverage.py
+++ b/py/coverage.py
@@ -25,7 +25,7 @@ def get_coverage_geojson_dict(cc, immediate_only=False):
 
 def get_coverage_file_path(cc):
     directory_path = "country_percent/countries/processed/"
-    return os.path.join(directory_path, f"{cc.upper()}.geojson")
+    return os.path.join(directory_path, f"{cc}.geojson")
 
 
 def has_coverage_file_immediate(cc):
@@ -80,7 +80,8 @@ def get_coverage_geojson_dict_from_regions(cc):
 
         region_code = os.path.splitext(os.path.basename(file_path))[0]
         total_area_m2 += geojson_data.get("total_area_m2") or sum(
-            f.get("properties", {}).get("area_m2", 0) for f in geojson_data.get("features", [])
+            f.get("properties", {}).get("area_m2", 0)
+            for f in geojson_data.get("features", [])
         )
 
         for feature in geojson_data.get("features", []):


### PR DESCRIPTION
and remove a different line that made the equivalent change, but way later down the call chain.
In particular, this PR changes it so that the cc is uppercased *before* interacting with the database. On the current deployment, https://trainlog.me/public/larsg/countries/be and https://trainlog.me/public/larsg/countries/BE both show the same coverage map, but create separate entries in the coverage_percent database table, thus resulting in duplicate entries for Belgium in the user dashboard and the coverage leaderboard. With this PR, the former will just redirect to the latter, resulting in all new database entries being uppercase only.

Once this PR is merged and deployed, running the following small SQL script will then also clean up the database table by merging all lines that just differ by casing (keeping the higher percentage value):
```sql
BEGIN;

WITH ranked AS (
  SELECT
    uid,
    ROW_NUMBER() OVER (
      PARTITION BY username, UPPER(cc)
      ORDER BY percent DESC, uid ASC
    ) AS rn
  FROM percents
)
DELETE FROM percents
WHERE uid IN (
  SELECT uid
  FROM ranked
  WHERE rn > 1
);

UPDATE percents
SET cc = UPPER(cc);

COMMIT;
```