### PR TITLE
Fix a cut in DE-HB

### DIFF
--- a/country_percent/countries/processed/DE-HB.geojson
+++ b/country_percent/countries/processed/DE-HB.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a9693324594d91d212d2860fc4468699c14cda5aa596a4ec015892c550ab4bce
-size 134449
+oid sha256:fe84f48b11b0c14f2cc3558eeb04ce883c73bc1647835c171ef78b23c25e4489
+size 134670


### PR DESCRIPTION
Two polygons touching at a vertex mistakenly were the same polygon instead of two different ones.