### PR TITLE
GB coverage: Split polygon near Farnborough

### DIFF
--- a/country_percent/countries/processed/GB-ENG.geojson
+++ b/country_percent/countries/processed/GB-ENG.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9ba9e1c2ab9afb7d8073da8c8e27c88bd3e748760a48796c4f1b4e85ef248bec
-size 15127758
+oid sha256:60633a94aad2c5072fc1ab53c6427437c5175f9deaac9d4f1d297b11a8267f49
+size 15056861


### PR DESCRIPTION
Large polygon near Farnborough which affects the North Downs, South West Main, Ascot to Aldershot, and Pirbright and Alton, lines, has been split into many smaller polygons.

- [x] I have run the `simplify_geojson.py` script.

---

As a side-note, I plan on doing a load more editing later on if this is all good, so this PR will not grow in scope, but I will make a larger PR later on to fix a lot of the issues raised in Discord in GB.