### PR TITLE
Simplify remaining US-*.geojson (partial: non-conflicting subset of #224)

### DIFF
--- a/country_percent/countries/processed/US-AL.geojson
+++ b/country_percent/countries/processed/US-AL.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ea4664064e6149c8ed8bffec6e43bdf87dcaf0e5ee07e3e448b619e58be2af7
-size 1054573
+oid sha256:b8301dd48ee46894c2fa8332038923fc365ac8edd62f6f1e9d0c285c709fe46e
+size 399599

--- a/country_percent/countries/processed/US-GA.geojson
+++ b/country_percent/countries/processed/US-GA.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:527ac1ae5f27837581f7e837d36fc1ee4b903ed92b37f23b6b7b7de32f28fcb3
-size 4517248
+oid sha256:012042b761cb7528f566d7422edf3091a9782fb776d1f74e01822151a3eddef5
+size 435472

--- a/country_percent/countries/processed/US-HI.geojson
+++ b/country_percent/countries/processed/US-HI.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1a892e024112dba8cbe44bd80585c228e7f035e8789cc0d63f9dbb989f22ca0d
-size 87356
+oid sha256:b37cb1a8ac306ef869b36f5e2f438e5c53e6a6406e810ec2b576110bf0a02cac
+size 40918

--- a/country_percent/countries/processed/US-KS.geojson
+++ b/country_percent/countries/processed/US-KS.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f5e2c0fe933d269cda5469cc77e25b472173383e3d47f41bb001f3c95a9ba830
-size 4147158
+oid sha256:90a6272cade232ba583edab53220c65c9116f79b2c04a0fa9ccf514266237afe
+size 386498

--- a/country_percent/countries/processed/US-LA.geojson
+++ b/country_percent/countries/processed/US-LA.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:61f48a5c3fe4123960c5c4b6c1f2e96dc5bd76a8b06600d16fe5dc2e30855650
-size 692704
+oid sha256:278eb57d9cb953eeff642e7bc7c514a102cf42021b2604feef183ebb5d743270
+size 244243

--- a/country_percent/countries/processed/US-MN.geojson
+++ b/country_percent/countries/processed/US-MN.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:3e7f1c35d1eddbe79e2c8a01f7e357488bd56463c2ce96c3dc7c7d49488aa52d
-size 1090810
+oid sha256:18ffd4b7e6f0f189e0d0815047602337a37ea44d3f24f34fc730f41b4ec2153c
+size 421177

--- a/country_percent/countries/processed/US-NC.geojson
+++ b/country_percent/countries/processed/US-NC.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:37e337d002d8606547edaadb278f0bfa6daf4610f1dc73807349cf81fc90f258
-size 8250966
+oid sha256:c9ff96ba6d8b6399e7d0e35f9c1f8feb9abf3a7ec084f362bd454891c54b8009
+size 828203

--- a/country_percent/countries/processed/US-OK.geojson
+++ b/country_percent/countries/processed/US-OK.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:670296e7bd640caa0f90721a57805ac7f592cfb923c0d544b951e20e518a5f75
-size 1587375
+oid sha256:3610e9d71bbe6afb4631f289c0af971540bdd0f8ee66609aaacc7ca8c0707f57
+size 156846

--- a/country_percent/countries/processed/US-SD.geojson
+++ b/country_percent/countries/processed/US-SD.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d687b88d64c329ad9bf6edfa922d674d02486224bd41b7905e8ac56d6068bbe0
-size 211261
+oid sha256:47751df5f4a641356b1a3badf0faf44efe6af7e9a88bf79ad70308529e9cb705
+size 24849

--- a/country_percent/countries/processed/US-WI.geojson
+++ b/country_percent/countries/processed/US-WI.geojson
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4dad87617a9b965cdd56a42c2eddb8cd0a99aed1428191de5f29de7310477ce0
-size 2441199
+oid sha256:83bb3962fb9ea8c0430c9955f6ce675d174957ebff32c9988088e2000046c468
+size 246230


### PR DESCRIPTION
Cherry-picks the 10 files from #224 that don't overlap with #235/#234/#228 (already merged): AL, GA, HI, KS, LA, MN, NC, OK, SD, WI.

The remaining 10 states in #224 (AK, AZ, DC, ID, MS, MT, ND, NY, SC, VA) conflict with those merged PRs and are left for #224 to be rebased separately.