### PR TITLE
Upgrade DataTables.js to 2.3.2 (rebased #30 + regression fixes)

### DIFF
--- a/app.py
+++ b/app.py
@@ -10198,7 +10198,7 @@ def stations_data():
 def stations():
     return render_template(
         "admin/stations.html",
-        username=get_user(),
+        username=getUser(),
         nav="bootstrap/navigation.html",
         isCurrent=has_current_trip(get_user_id()),
         **lang[session["userinfo"]["lang"]],

--- a/static/styles/style2.css
+++ b/static/styles/style2.css
@@ -1700,15 +1700,6 @@ html, body {
 }
 
 
-table.dataTable.dtr-column>tbody>tr>td.dtr-control:before,
-table.dataTable.dtr-column>tbody>tr>th.dtr-control:before,
-table.dataTable.dtr-column>tbody>tr>td.control:before,
-table.dataTable.dtr-column>tbody>tr>th.control:before {
-
-  height:1em;
-  width:1em;
-}
-
 .leaderboardLink{
   text-decoration: none;
   transition: filter 0.1s;

--- a/static/styles/style2.css
+++ b/static/styles/style2.css
@@ -1725,7 +1725,7 @@ table.dataTable.dtr-column>tbody>tr>th.control:before {
   filter: brightness(500%);
 }
 
-.dataTables_wrapper .dataTables_filter{
+.dt-container .dt-search {
   margin-bottom: 5px;
   text-align: center;
 }
@@ -1759,7 +1759,7 @@ table.dataTable.dtr-column>tbody>tr>th.control:before {
   background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23343a40' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 11 6-6 6 6'/%3e%3c/svg%3e");
 }
 @media (min-width: 768px) {
-  .dataTables_wrapper .dataTables_filter {
+  .dt-container .dt-search {
     text-align: right;
   }
 }

--- a/static/styles/style2.css
+++ b/static/styles/style2.css
@@ -152,6 +152,7 @@
   margin: 2px;
   user-select: none;
   text-decoration: none;
+  white-space: nowrap;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
 }
 
@@ -212,8 +213,11 @@
   color:#c9c5c5
 }
 
+/* Hidden, not removed: `display:none` would drop the arrow's box and its
+   margin, pulling this row's content left out of line with the rows that do
+   have something to expand. */
 td.noHidden::before{
-  display: none !important;
+  visibility: hidden !important;
 }
 
 td.noHidden{
@@ -228,11 +232,6 @@ td.noHidden{
 .trips select {
   color: black;
 }
-
-td.child table tr td{
-  max-width: max-content !important;
-}
-
 
 th {
   background-color: #207cca !important;
@@ -412,6 +411,50 @@ td.actionButtons{
   overflow: hidden;
 }
 
+/* The detail row and everything nested in it: both the colspan'd wrapper cell and
+   the label/value cells of the subtable inside it match `#dataTable tbody td`
+   above, so without this they inherit the 120px cap meant for real columns. */
+#dataTable tbody td.child,
+#dataTable tbody td.child table td{
+  max-width: none;
+}
+
+/* A half-shown date is useless (2026-03-… says nothing), and it is a fixed, short
+   string, so it keeps its full width instead of taking a share of the ellipsis
+   budget — including at the narrower mobile cap below. */
+#dataTable tbody td.tripDate{
+  max-width: none;
+  white-space: nowrap;
+}
+
+/* Everything below is scoped to the wrapper, not #dataTable: with scrolling on,
+   DataTables clones the header into .dt-scroll-head and drops the id from the clone,
+   so an #dataTable-scoped rule never reaches the header that is actually on screen.
+   The wrapper contains both the cloned header and the real body table. */
+
+/* DataTables 2 right-aligns whatever it detects as a date or a number, which nothing
+   else here does and which pushes those values away from their column titles. */
+#dataTable_wrapper th.dt-type-date,
+#dataTable_wrapper td.dt-type-date,
+#dataTable_wrapper th.dt-type-numeric,
+#dataTable_wrapper td.dt-type-numeric{
+  text-align: left !important;
+}
+
+/* Each header is a flex row (span.dt-column-title inside div.dt-column-header) whose
+   title is set to grow, and for the columns DataTables detects as date/numeric the
+   row is reversed. That parks those titles hard right — where this table's own
+   absolutely positioned sort arrows sit — while every other title stays left, and it
+   makes the gap to the arrows depend on how much slack the column happens to have.
+   One direction, no growing: the title sits left and clear of the arrows everywhere. */
+#dataTable_wrapper thead > tr > th div.dt-column-header{
+  flex-direction: row;
+  justify-content: flex-start;
+}
+#dataTable_wrapper thead > tr > th div.dt-column-header span.dt-column-title{
+  flex-grow: 0;
+}
+
 #dataTable tbody td.flagList{
   min-width:120px;
   text-overflow:unset ;
@@ -419,18 +462,40 @@ td.actionButtons{
   white-space: unset;
 }
 
+/* The subtable has no intrinsic width, so without this it shrink-to-fits and
+   piles every label/value against the left edge of a full-width row. */
+td.child > table{
+  width: 100%;
+}
+
+/* Label column: wide enough for the longest label, so the values line up in a
+   column instead of each row setting its own split. */
+td.child table tr td:first-child{
+  width: 1%;
+  /* Beats the `white-space: normal !important` below, which is meant for values. */
+  white-space: nowrap !important;
+  padding-right: 16px;
+}
+
+/* Content only lands in the responsive child/subtable because it didn't fit the
+   fixed-width main row; ellipsing it there again would defeat the point, so this
+   is not scoped to the mobile media query below. */
+td.child table tr td{
+  white-space: normal !important;
+  text-overflow:unset !important;
+  overflow:auto !important;
+  padding: 8px 4px;
+  /* Baseline, not top: a value starting with a flag has a taller line box than
+     its label, so top-aligning the cells leaves the two texts off by a few px. */
+  vertical-align: baseline;
+}
+td.child table tr:not(:last-child) td{
+  border-bottom: 1px solid rgba(0, 0, 0, 0.07);
+}
+
 @media screen and (max-width: 600px) {
   #dataTable tbody td{
     max-width: 100px;
-  }
-
-  td.child table tr td{
-    white-space: normal !important;
-    text-overflow:unset !important;
-    overflow:auto !important;
-  }
-  td.child table tr{
-    width:100%;
   }
 
   .trips{
@@ -1720,11 +1785,21 @@ html, body {
   margin-bottom: 5px;
   text-align: center;
 }
-.dataTables_wrapper .dataTables_filter input {
+.dt-container .dt-search input {
   /* The body font is FlagEmojis-first; that flag-only font makes the browser
      mis-measure this search box's `size`-based intrinsic width, ballooning it
      to full width (notably on mobile). Reset to a normal text stack. */
   font-family: Arial, Helvetica, sans-serif;
+}
+
+/* Narrow screens have no room for Previous/Next beside the page numbers, and the
+   pagingType option that would drop them is only read once at init, so it cannot
+   react to a resize. Scoped to the trips table's own bottom bar. */
+@media screen and (max-width: 767px) {
+  .dt-controls-bottom .dt-paging-button.previous,
+  .dt-controls-bottom .dt-paging-button.next {
+    display: none;
+  }
 }
 .dt-sort-btn {
   display: inline-block;

--- a/templates/admin/airliners.html
+++ b/templates/admin/airliners.html
@@ -5,8 +5,8 @@
 
 <div class="container">
     <h1 class="mt-3">Airliners</h1>
-    <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#airlinerModal" onclick="clearForm()">Add Airliner</button>
-    <table id="airlinerTable" class="mt-3">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#airlinerModal" onclick="clearForm()">Add Airliner</button>
+    <table id="airlinerTable">
         <thead>
             <tr>
                 <th scope="col" data-priority=1>IATA</th>

--- a/templates/admin/operators.html
+++ b/templates/admin/operators.html
@@ -213,7 +213,7 @@
         <input type="file" id="importCsvFile" accept=".csv" style="display:none" onchange="importOperatorsCsv(this)">
         <span id="consistencyStatus"></span>
     </div>
-    <table id="operatorTable" class="mt-3">
+    <table id="operatorTable">
         <thead>
             <tr>
                 <th scope="col" data-priority=1>ID</th>

--- a/templates/admin/ships.html
+++ b/templates/admin/ships.html
@@ -5,8 +5,8 @@
 
 <div class="container">
     <h1 class="mt-3">Ships</h1>
-    <button type="button" class="btn btn-primary mb-3" data-bs-toggle="modal" data-bs-target="#shipModal" onclick="clearForm()">Add Ship</button>
-    <table id="shipTable" class="mt-3">
+    <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#shipModal" onclick="clearForm()">Add Ship</button>
+    <table id="shipTable">
         <thead>
             <tr>
                 <th scope="col">Vessel Name</th>

--- a/templates/admin/stations.html
+++ b/templates/admin/stations.html
@@ -19,7 +19,7 @@
 
 <div class="container">
     <h1 class="mt-3">Stations</h1>
-    <table id="stationsTable" class="table mt-3">
+    <table id="stationsTable">
         <thead>
             <tr>
                 <th scope="col">Name</th>

--- a/templates/bootstrap/layout.html
+++ b/templates/bootstrap/layout.html
@@ -44,10 +44,10 @@
     <!-- Jquery -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jquery-ui-dist@1.13.2/jquery-ui.min.css">
     <!-- Jquery DataTables -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/datatables.net-dt@1.13.4/css/jquery.dataTables.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/datatables.net-responsive-dt@2.4.1/css/responsive.dataTables.min.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/datatables.net-select-dt@1.6.2/css/select.dataTables.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/datatables.net-dt@2.3.2/css/dataTables.dataTables.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/datatables.net-responsive-dt@3.0.5/css/responsive.dataTables.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/datatables.net-scroller-dt@2.4.3/css/scroller.dataTables.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/datatables.net-select-dt@3.0.1/css/select.dataTables.min.css">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-colorpicker@3.4.0/dist/css/bootstrap-colorpicker.css">
 
 
@@ -69,11 +69,11 @@
       <script type="text/javascript" language="javascript" src="https://code.jquery.com/jquery-3.5.1.js"></script>
       <script type="text/javascript" language="javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
     <!-- Jquery DataTables -->
-      <script src="https://cdn.jsdelivr.net/npm/datatables.net@1.13.4/js/jquery.dataTables.min.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/datatables.net-responsive@2.4.1/js/dataTables.responsive.min.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/datatables.net-select@1.6.2/js/dataTables.select.min.js"></script>
-      <script src="https://cdn.jsdelivr.net/npm/datatables.net-plugins@2.3.2/dataRender/ellipsis.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/datatables.net@2.3.2/js/dataTables.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/datatables.net-responsive@3.0.5/js/dataTables.responsive.min.js"></script>
       <script src="https://cdn.jsdelivr.net/npm/datatables.net-scroller@2.4.3/js/dataTables.scroller.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/datatables.net-select@3.0.1/js/dataTables.select.min.js"></script>
+      <script src="https://cdn.jsdelivr.net/npm/datatables.net-plugins@2.3.2/dataRender/ellipsis.js"></script>
 
     <!-- bootstrap -->
       <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.10.2/dist/umd/popper.min.js"></script>

--- a/templates/dynamic_trips.html
+++ b/templates/dynamic_trips.html
@@ -7,10 +7,10 @@
     /* --- General UI --- */
     .ui-front { z-index: 9999999 !important; }
 
-    #dataTable_wrapper { min-height: 600px; }
+    .dt-container { min-height: 600px; }
 
     @media screen and (max-width: 767px) {
-        #dataTable_wrapper { margin-top: 15px; }
+        .dt-container { margin-top: 15px; }
     }
 
     /* Trainset picker in edit/new forms */
@@ -1426,7 +1426,7 @@ $(document).on('mousedown', '.editButton, .copyButton', function() {
 
 (function() {
     var $btn = $('<label>{{sortTitle}} : <button id="sortTriggerBtn" class="dt-sort-btn" type="button" data-bs-toggle="modal" data-bs-target="#sortModal"></button></label>');
-    $(tableObject.table().container()).find('.dt-controls .dataTables_filter').before($btn);
+    $(tableObject.table().container()).find('.dt-controls .dt-search').before($btn);
     updateSortButton();
 })();
 
@@ -1435,7 +1435,7 @@ $(document).on('mousedown', '.editButton, .copyButton', function() {
         <input class="form-check-input" type="checkbox" id="filterTypeSwitch" onchange="toggleTypeFilter()">
         <label class="form-check-label" for="filterTypeSwitch">{{showPlaces}}</label>
     </div>`);
-    $(tableObject.table().container()).find('.dt-controls .dataTables_filter').before($switch);
+    $(tableObject.table().container()).find('.dt-controls .dt-search').before($switch);
 {% endif %}
 
 {% if not projects %}
@@ -1588,7 +1588,7 @@ function updateSelectionMessage() {
             ? ""
             : pluralize(dtRowsSelected, checkedTrips.length);
 
-        var $dataTablesInfo = $('.dataTables_info');
+        var $dataTablesInfo = $('.dt-info');
 
         // Check if .select-info class exists
         if ($dataTablesInfo.find('.select-info').length === 0) {
@@ -2332,7 +2332,7 @@ $('#submitBtn').on('click', function() {
         }
 
         setTimeout(function() {
-            var searchContainer = $('.dataTables_filter');
+            var searchContainer = $('.dt-search');
             if (searchContainer.length && !searchContainer.find('.search-help-icon').length) {
                 var $input = searchContainer.find('input');
                 var $wrapper = $('<span style="display:inline-flex;align-items:center;gap:1px;"></span>');
@@ -2346,9 +2346,9 @@ $('#submitBtn').on('click', function() {
 
     function addPageJumpInput() {
         // Only add if it doesn't already exist
-        if ($('.dataTables_paginate input.page-jump-input').length === 0) {
+        if ($('.dt-paging input.page-jump-input').length === 0) {
             $('<input type="number" placeholder="#" class="form-control page-jump-input" style="width: 70px; margin-left: 10px; display: inline-block;" min="1">')
-                .appendTo($('.dataTables_paginate'))
+                .appendTo($('.dt-paging'))
                 .on('keyup blur', function(e) {
                     if (e.type === 'keyup' && e.key !== 'Enter') return;
                     if (!this.value) return;

--- a/templates/dynamic_trips.html
+++ b/templates/dynamic_trips.html
@@ -550,13 +550,42 @@ function toggleIncludeFuture() {
 
 function isEllipsisActive(el){
   if (!el) return false;
-  if (el.scrollWidth > el.clientWidth) return true;
-  const styles = getComputedStyle(el);
-  const widthEl = parseFloat(styles.width);
-  const ctx = document.createElement('canvas').getContext('2d');
-  ctx.font = `${styles.fontSize} ${styles.fontFamily}`;
-  const text = ctx.measureText(el.innerText);
-  return text.width > widthEl;
+  // Sub-pixel column widths make scrollWidth/clientWidth differ by a fraction on
+  // cells that are not actually clipped, so require a whole pixel of overflow.
+  if (el.scrollWidth > el.clientWidth + 1) return true;
+  // Only text can be ellipsed. Icon-only cells (a logo, or a hidden span holding the
+  // sort key) have nothing to truncate, so they must not be measured: their content
+  // is sized to the column and the correction below would read that as an overflow.
+  if (!el.innerText || !el.innerText.trim()) return false;
+  // Measure what is really laid out rather than re-measuring the text on a canvas:
+  // these cells start with a flag and can hold logos, and the canvas path measured
+  // el.innerText (images contribute nothing, the flag glyph is measured in the
+  // FlagEmojis-first body stack) so its widths did not reflect the rendered cell.
+  try {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    // A range only covers DOM nodes, so the responsive control arrow — a ::before
+    // on whichever column is first visible — is missed, and that cell alone reads
+    // ~18px narrower than it renders. Add the pseudo-element back in.
+    let width = range.getBoundingClientRect().width;
+    const before = getComputedStyle(el, '::before');
+    if (before && before.content !== 'none') {
+      width += (parseFloat(before.width) || 0)
+             + (parseFloat(before.borderLeftWidth) || 0)
+             + (parseFloat(before.borderRightWidth) || 0)
+             + (parseFloat(before.marginRight) || 0);
+    }
+    // clientWidth spans the padding box but the range spans only the content, so
+    // comparing them straight gives every cell a free ~20px of overflow (the
+    // theme's 10px cell padding either side) before it counts as clipped.
+    const styles = getComputedStyle(el);
+    const available = el.clientWidth
+                    - (parseFloat(styles.paddingLeft) || 0)
+                    - (parseFloat(styles.paddingRight) || 0);
+    return width > available + 1;
+  } catch (e) {
+    return false;
+  }
 }
 
 function processHiddenData(rowIdx, columns){
@@ -1219,8 +1248,16 @@ var table = $('#tripRows');
     searchDelay: 1000,
     scrollY: scroll == true ? $(window).height() - 300 : null,
     scroller: scroll,
-    dom: '<"dt-controls d-flex flex-wrap justify-content-center justify-content-md-between align-items-center gap-2 mb-2"lf>rtip',
+    dom: '<"dt-controls d-flex flex-wrap justify-content-center justify-content-md-between align-items-center gap-2 mb-2"lf>rt<"dt-controls-bottom d-flex flex-wrap justify-content-center justify-content-md-between align-items-center gap-2 mt-2"ip>',
     columnDefs: [{ orderable: false, targets: '_all' }],
+    // Every column is orderable:false and sorting runs through the "Trier" dropdown
+    // below, but DataTables 2 decides whether to draw a header sort arrow from a
+    // data-dt-order attribute rather than from the column being orderable, so it
+    // marks up an indicator on every header that nothing can act on. This has to be
+    // the object form: a top-level `orderIndicators` is overwritten during init by
+    // `else if (init.bSort === true) { init.orderIndicators = true; ... }`, which
+    // fires because ordering defaults to true.
+    ordering: { indicators: false, handler: false },
     ajax: {
         url: '{{ url_for("get_trips_api" if not isPublic else "get_trips_api_public", username=username, projects=projects) }}',
         "type": "POST",
@@ -1261,7 +1298,7 @@ var table = $('#tripRows');
         { data: 'type', render: renderType },
         { data: 'origin_station', render: renderStation },
         { data: 'destination_station', render: renderStation },
-        { data: 'start_date' },
+        { data: 'start_date', className: 'tripDate' },
         { data: 'start_time', render: renderStartTime },
         { data: 'end_time', render: renderEndTime },
         { data: 'trip_duration', render: renderDuration },
@@ -1617,34 +1654,35 @@ $('.deleteButton').off('click').on('click', function() {
 });
 
     tableObject.rows().every( function ( rowIdx, tableLoop, rowLoop ) {
-        if ($(this.node()).hasClass("even") || $(this.node()).hasClass("odd")){
-            var controlElement;
-            var rowData = this.data();
-            // Seeded true when the detail row carries something that is not a cell
-            // responsive hid: a delay breakdown, or operators beyond the four the
-            // compact cell can show. Either way the control must stay usable, since
-            // the detail row is the only place that content exists.
-            var hasHidden = Boolean(rowData && (
-                rowData.departure_delay || rowData.arrival_delay || operatorsOverflow(rowData)
-            ));
-            $(this.node()).children().each(
-                function(index, element){
-                    if ($(element).hasClass("dtr-control"))
-                    {
-                      controlElement = $(element)
-                    }
-                    if($(element).is(':hidden')){
-                        if($(element).text() != ""){
-                            hasHidden = true;
-                        }
-                    }
-
+        // No even/odd guard: DataTables 2 stripes rows with CSS :nth-child instead
+        // of the odd/even classes 1.x put on every <tr>, so testing for them here
+        // skipped every row and the control was never marked as having nothing to open.
+        var controlElement;
+        var rowData = this.data();
+        // Seeded true when the detail row carries something that is not a cell
+        // responsive hid: a delay breakdown, or operators beyond the four the
+        // compact cell can show. Either way the control must stay usable, since
+        // the detail row is the only place that content exists.
+        var hasHidden = Boolean(rowData && (
+            rowData.departure_delay || rowData.arrival_delay || operatorsOverflow(rowData)
+        ));
+        $(this.node()).children().each(
+            function(index, element){
+                if ($(element).hasClass("dtr-control"))
+                {
+                  controlElement = $(element)
                 }
-            );
+                if($(element).is(':hidden')){
+                    if($(element).text() != ""){
+                        hasHidden = true;
+                    }
+                }
 
-            if(!hasHidden) {
-                controlElement.addClass("noHidden");
             }
+        );
+
+        if (controlElement) {
+            controlElement.toggleClass("noHidden", !hasHidden);
         }
     });
 }
@@ -2347,8 +2385,11 @@ $('#submitBtn').on('click', function() {
     function addPageJumpInput() {
         // Only add if it doesn't already exist
         if ($('.dt-paging input.page-jump-input').length === 0) {
+            // DataTables 2 wraps the buttons in a <nav> inside .dt-paging, so appending
+            // to .dt-paging itself would drop the box onto its own line below them.
+            var $pagingNav = $('.dt-paging nav');
             $('<input type="number" placeholder="#" class="form-control page-jump-input" style="width: 70px; margin-left: 10px; display: inline-block;" min="1">')
-                .appendTo($('.dt-paging'))
+                .appendTo($pagingNav.length ? $pagingNav : $('.dt-paging'))
                 .on('keyup blur', function(e) {
                     if (e.type === 'keyup' && e.key !== 'Enter') return;
                     if (!this.value) return;

--- a/templates/leaderboard.html
+++ b/templates/leaderboard.html
@@ -15,14 +15,14 @@
 </div>
 
 <div id="leaderboard-container" class="container mt-3">
-    <h2>
+    <h1>
         {% if type == "all" %}
             {{ leaderboardTotal }}
         {% else %}
             {{ transport_types[type] }}
         {% endif %}
-    </h2>
-    
+    </h1>
+
     <br>
     
     {% include "leaderboardNav.html"%}
@@ -30,7 +30,7 @@
     <br>
 
     <table id="leaderboard" class="table table-striped table-bordered display nowrap">
-        <thead class="thead">
+        <thead>
             <tr>
                 <th></th>
                 <th>{{ leaderboardRank }}</th>

--- a/templates/leaderboardNav.html
+++ b/templates/leaderboardNav.html
@@ -1,4 +1,4 @@
-<div class="leaderboard-switcher text-center my-3">
+<div class="leaderboard-switcher text-center">
   <!-- Desktop / tablet -->
   <div class="d-none d-md-flex justify-content-center flex-wrap gap-2">
     <a href="{{ url_for('leaderboard', type='all') }}"

--- a/templates/leaderboard_carbon.html
+++ b/templates/leaderboard_carbon.html
@@ -8,9 +8,9 @@
 </div>
 
 <div id="leaderboard-container" class="container mt-3">
-    <h2>
+    <h1>
         {{ leaderboardCarbonTitle if leaderboardCarbonTitle is defined else 'Carbon leaderboard' }}
-    </h2>
+    </h1>
     
     <br>
 
@@ -19,7 +19,7 @@
     <br>
 
     <table id="leaderboard" class="table table-striped table-bordered display nowrap">
-        <thead class="thead">
+        <thead>
             <tr>
                 <th></th>
                 <th>{{ leaderboardRank }}</th>

--- a/templates/leaderboard_countries.html
+++ b/templates/leaderboard_countries.html
@@ -8,10 +8,10 @@
 </div>
 
 <div id="leaderboard-container" class="container mt-3">
-    <h2>
+    <h1>
         {{ countryCountLeaderboard }}
-    </h2>
-    
+    </h1>
+
     <br>
     
     {% include "leaderboardNav.html"%}
@@ -19,7 +19,7 @@
     <br>
 
     <table id="leaderboard" class="table table-bordered display nowrap">
-        <thead class="thead">
+        <thead>
             <tr>
                 <th class="rank-column" style="white-space: nowrap;">{{ leaderboardRank }}</th>
                 <th>{{ leaderboardUsername }}</th>

--- a/templates/leaderboard_train_countries.html
+++ b/templates/leaderboard_train_countries.html
@@ -8,17 +8,17 @@
 </div>
 
 <div id="leaderboard-container" class="container mt-3">
-    <h2>
+    <h1>
         {{ leaderboardCountries }}
-    </h2>
-    
+    </h1>
+
     <br>
     {% include "leaderboardNav.html"%}
 
     <br>
 
     <table id="leaderboard" class="table table-bordered display nowrap">
-        <thead class="thead">
+        <thead>
             <tr>
                 <th></th>
                 <th class="all">{{ leaderboardCountry }}</th>
@@ -146,12 +146,13 @@ $.get('{{url_for("getLeaderboardUsers", type=type)}}', function(countries, statu
     });
 
     const dTable = $('#leaderboard').DataTable({
-        paging: false, // Don't want paging                
-        bPaginate: false, // Don't want paging   
+        paging: false, // Don't want paging
+        bPaginate: false, // Don't want paging
         columnDefs: [
             {
                 className: 'dtr-control',
                 orderable: false,
+                width: '1em',
                 target: 0
             },
             {

--- a/templates/leaderboard_world_squares.html
+++ b/templates/leaderboard_world_squares.html
@@ -7,9 +7,9 @@
 </div>
 
 <div id="leaderboard-container" class="container mt-3">
-    <h2>
+    <h1>
         {{worldSquares}}
-    </h2>
+    </h1>
     
     <br>
     
@@ -18,7 +18,7 @@
     <br>
 
     <table id="leaderboard" class="table table-bordered display nowrap">
-        <thead class="thead">
+        <thead>
             <tr>
                 <th>{{ leaderboardRank }}</th>
                 <th>{{ leaderboardUsername }}</th>

--- a/templates/tag_list.html
+++ b/templates/tag_list.html
@@ -376,16 +376,32 @@
 
 <script>
   $(document).ready(function() {
-    $('#tagsTable').DataTable(
-      {
-        order: [],
-        responsive:true,
-        lengthMenu: [[10, 50, 100, -1], [10, 50, 100, "All"]],
-        drawCallback: function(settings) {
-          updateTagColors();
-        }
-      }
-    );
+    var table = $('#tagsTable').DataTable({
+      order: [],
+      responsive: true,
+      lengthMenu: [[10, 50, 100, -1], [10, 50, 100, "All"]],
+      drawCallback: function(settings) {
+        updateTagColors();
+      },
+      language: {
+        info: "{{dtInfo}}",
+        paginate: {
+          next: "{{dtNext}}",
+          previous: "{{dtPrevious}}",
+        },
+        emptyTable: "{{dtEmptyTable}}",
+        select: {
+          rows: {
+            "_": "{{dtMultipleLineSelected}}",
+            "0": "",
+            "1": "{{dtOneLineSelected}}"
+          },
+        },
+        lengthMenu: "{{dtLengthMenu}}",
+        search: "{{dtSearch}}"
+      },
+    });
+    
     function updateTagColors() {
       {% for tag in tagsList %}
       $("#colour-{{ tag.uid }}").css("color", getTextColor("{{ tag.colour }}"));

--- a/templates/ticket_list.html
+++ b/templates/ticket_list.html
@@ -11,109 +11,104 @@
     }
 </style>
 
-<div class="container-xxl mt-4 mb-4">
-    <div class="row">
-        <div class="col-12">
-            <h2 class="mb-4">{{nav_tickets}}</h2>
+<div class="container-xxl">
+    <h1 class="mt-3">{{nav_tickets}}</h1>
 
-            <!-- NEW: toggle inactive tickets (DataTables-native filtering; no CSS hide) -->
-            <div class="mb-3">
-                <button id="toggleInactiveTickets" type="button" class="btn btn-outline-secondary btn-sm">
-                    <i class="fa-regular fa-eye"></i> {{show_inactive_tickets}}
-                </button>
-            </div>
+    <!-- NEW: toggle inactive tickets (DataTables-native filtering; no CSS hide) -->
+    <div>
+        <button id="toggleInactiveTickets" type="button" class="btn btn-outline-secondary btn-sm">
+            <i class="fa-regular fa-eye"></i> {{show_inactive_tickets}}
+        </button>
+    </div>
 
-            <div class="table-responsive">
-                <table id="ticketsTable" class="table table-hover w-100">
-                    <thead class="table-light">
-                        <tr>
-                            <th data-priority="1" class="px-3 py-3 border-0">{{ticket_name}}</th>
-                            <th class="px-3 py-3 border-0">{{price}}</th>
-                            <th data-priority="2" class="px-3 py-3 border-0">{{purchasing_date}}</th>
-                            <th class="px-3 py-3 border-0">{{trips}}</th>
-                            <th class="px-3 py-3 border-0">{{price_per_trip}}</th>
-                            <th class="px-3 py-3 border-0">{{price_per_km}}</th>
-                            <th data-orderable="false" data-priority="1" class="px-3 py-3 text-center border-0">{{active}}</th>
-                            <th data-orderable="false" class="px-3 py-3 text-center border-0">{{ticketCountries}}</th>
-                            <th class="px-3 py-3 border-0">{{notes}}</th>
-                            <th data-orderable="false" data-priority="1" class="px-3 py-3 text-center border-0"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {% for ticket in tickets %}
-                        <!-- CHANGED: add inactive marker class only -->
-                        <tr id="row_{{ ticket.uid }}" class="{% if not ticket.active %}ticket-inactive{% endif %}">
-                            <td class="px-3 py-3 fw-medium border-0">{{ ticket.name }}</td>
-                            <td class="px-3 py-3 price-format border-0" data-price="{{ ticket.price }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">
-                                <span><span style="display:none;" class="price-format-hidden" data-price="{{ ticket.price }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">{{ ticket.price_in_user_currency }}</span></span>
-                            </td>
-                            <td class="px-3 py-3 border-0">{{ ticket.purchasing_date }}</td>
-                            <td class="px-3 py-3 border-0">
-                                {% if ticket.trip_ids %}
-                                    <a class="leaderboardLink link-dark text-decoration-none fw-medium" href="{{ url_for('public_trip', ticketId=ticket.uid) }}?price">{{ ticket.trip_count }}</a>
-                                {% else %}
-                                    {{ ticket.trip_count }}
-                                {% endif %}
-                            </td>
-                            <td class="px-3 py-3 border-0">
-                                {% if ticket.price_per_trip %}
-                                    <span class="price-format" data-price="{{ ticket.price_per_trip }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_per_trip_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">
-                                        <span style="display:none;" class="price-format-hidden" data-price="{{ ticket.price_per_trip }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_per_trip_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">{{ ticket.price_per_trip_in_user_currency }}</span>
-                                    </span>
-                                {% endif %}
-                            </td>
-                            <td class="px-3 py-3 border-0">
-                                {% if ticket.price_per_km %}
-                                    <span class="price-format" data-price="{{ ticket.price_per_km }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_per_km_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">
-                                        <span style="display:none;" class="price-format-hidden" data-price="{{ ticket.price_per_km }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_per_km_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">{{ ticket.price_per_km_in_user_currency }}</span>
-                                    </span>
-                                {% endif %}
-                            </td>
-                            <td class="px-3 py-3 text-center border-0">
-                                <div class="form-check form-switch d-flex justify-content-center">
-                                    <input class="form-check-input ticket-active-checkbox"
-                                           type="checkbox"
-                                           role="switch"
-                                           data-ticket-id="{{ ticket.uid }}"
-                                            {% if ticket.active %}
-                                                checked
-                                            {%endif%}
-                                           >
-                                </div>
-                            </td>
-                            <td class="px-3 py-3 text-center border-0">
-                                {% if ticket.active_countries %}
-                                    <div class="country-flags-container">
-                                        {% for country in ticket.active_countries.split(',') %}
-                                            <span class="flag me-1" data-bs-toggle="tooltip" style="cursor:context-menu;" data-bs-placement="top" title="{{ country }}">{{ country_list[country] }}</span>
-                                        {% endfor %}
-                                    </div>
-                                {% endif %}
-                            </td>
-                            <td class="px-3 py-3 border-0">
-                                {% if ticket.notes %}
-                                    <span class="text-muted">{{ ticket.notes }}</span>
-                                {% endif %}
-                            </td>
-                            <td class="px-3 py-3 text-center border-0">
-                                <div class="btn-group btn-group-sm" role="group">
-                                    <button class="btn btn-warning editButton" data-ticket-id="{{ ticket.uid }}" data-ticket-name="{{ ticket.name }}" data-ticket-price="{{ ticket.price }}" data-ticket-currency="{{ ticket.currency }}" data-ticket-date="{{ ticket.purchasing_date }}" data-ticket-notes="{{ ticket.notes }}" data-ticket-active-countries="{{ ticket.active_countries }}">
-                                        <i class="fa-regular fa-pen-to-square"></i>
-                                    </button>
-                                    <button class="btn btn-danger deleteButton" data-ticket-id="{{ ticket.uid }}">
-                                        <i class="fa-regular fa-trash-can"></i>
-                                    </button>
-                                </div>
-                            </td>
-                        </tr>
-                        {% endfor %}
-                    </tbody>
-                </table>
-            </div>
-        </div>
+    <div class="table-responsive">
+        <table id="ticketsTable" class="table table-hover w-100">
+            <thead class="table-light">
+                <tr>
+                    <th data-priority="1" class="px-3 py-3 border-0">{{ticket_name}}</th>
+                    <th class="px-3 py-3 border-0">{{price}}</th>
+                    <th data-priority="2" class="px-3 py-3 border-0">{{purchasing_date}}</th>
+                    <th class="px-3 py-3 border-0">{{trips}}</th>
+                    <th class="px-3 py-3 border-0">{{price_per_trip}}</th>
+                    <th class="px-3 py-3 border-0">{{price_per_km}}</th>
+                    <th data-orderable="false" data-priority="1" class="px-3 py-3 text-center border-0">{{active}}</th>
+                    <th data-orderable="false" class="px-3 py-3 text-center border-0">{{ticketCountries}}</th>
+                    <th class="px-3 py-3 border-0">{{notes}}</th>
+                    <th data-orderable="false" data-priority="1" class="px-3 py-3 text-center border-0"></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for ticket in tickets %}
+                <!-- CHANGED: add inactive marker class only -->
+                <tr id="row_{{ ticket.uid }}" class="{% if not ticket.active %}ticket-inactive{% endif %}">
+                    <td class="px-3 py-3 fw-medium border-0">{{ ticket.name }}</td>
+                    <td class="px-3 py-3 price-format border-0" data-price="{{ ticket.price }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">
+                        <span><span style="display:none;" class="price-format-hidden" data-price="{{ ticket.price }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">{{ ticket.price_in_user_currency }}</span></span>
+                    </td>
+                    <td class="px-3 py-3 border-0">{{ ticket.purchasing_date }}</td>
+                    <td class="px-3 py-3 border-0">
+                        {% if ticket.trip_ids %}
+                            <a class="leaderboardLink link-dark text-decoration-none fw-medium" href="{{ url_for('public_trip', ticketId=ticket.uid) }}?price">{{ ticket.trip_count }}</a>
+                        {% else %}
+                            {{ ticket.trip_count }}
+                        {% endif %}
+                    </td>
+                    <td class="px-3 py-3 border-0">
+                        {% if ticket.price_per_trip %}
+                            <span class="price-format" data-price="{{ ticket.price_per_trip }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_per_trip_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">
+                                <span style="display:none;" class="price-format-hidden" data-price="{{ ticket.price_per_trip }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_per_trip_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">{{ ticket.price_per_trip_in_user_currency }}</span>
+                            </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-3 py-3 border-0">
+                        {% if ticket.price_per_km %}
+                            <span class="price-format" data-price="{{ ticket.price_per_km }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_per_km_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">
+                                <span style="display:none;" class="price-format-hidden" data-price="{{ ticket.price_per_km }}" data-currency="{{ ticket.currency }}" data-user-price="{{ ticket.price_per_km_in_user_currency }}" data-user-currency="{{ ticket.user_currency }}">{{ ticket.price_per_km_in_user_currency }}</span>
+                            </span>
+                        {% endif %}
+                    </td>
+                    <td class="px-3 py-3 text-center border-0">
+                        <div class="form-check form-switch d-flex justify-content-center">
+                            <input class="form-check-input ticket-active-checkbox"
+                                    type="checkbox"
+                                    role="switch"
+                                    data-ticket-id="{{ ticket.uid }}"
+                                    {% if ticket.active %}
+                                        checked
+                                    {%endif%}
+                                    >
+                        </div>
+                    </td>
+                    <td class="px-3 py-3 text-center border-0">
+                        {% if ticket.active_countries %}
+                            <div class="country-flags-container">
+                                {% for country in ticket.active_countries.split(',') %}
+                                    <span class="flag me-1" data-bs-toggle="tooltip" style="cursor:context-menu;" data-bs-placement="top" title="{{ country }}">{{ country_list[country] }}</span>
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                    </td>
+                    <td class="px-3 py-3 border-0">
+                        {% if ticket.notes %}
+                            <span class="text-muted">{{ ticket.notes }}</span>
+                        {% endif %}
+                    </td>
+                    <td class="px-3 py-3 text-center border-0">
+                        <div class="btn-group btn-group-sm" role="group">
+                            <button class="btn btn-warning editButton" data-ticket-id="{{ ticket.uid }}" data-ticket-name="{{ ticket.name }}" data-ticket-price="{{ ticket.price }}" data-ticket-currency="{{ ticket.currency }}" data-ticket-date="{{ ticket.purchasing_date }}" data-ticket-notes="{{ ticket.notes }}" data-ticket-active-countries="{{ ticket.active_countries }}">
+                                <i class="fa-regular fa-pen-to-square"></i>
+                            </button>
+                            <button class="btn btn-danger deleteButton" data-ticket-id="{{ ticket.uid }}">
+                                <i class="fa-regular fa-trash-can"></i>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
     </div>
 </div>
-<div class="mb-4 mt-4"></div>
 
 <!-- Edit Ticket Modal -->
 <div class="modal fade" id="editTicketModal" tabindex="-1" aria-labelledby="editTicketModalLabel" aria-hidden="true">


### PR DESCRIPTION
Rebase of #30 by @lgoettgens onto current main (its base was ~200 commits behind), plus fixes for the regressions the upgrade introduced.

Original three commits are unchanged in intent and keep their authorship. Conflicts were in `templates/tag_list.html` and `templates/admin/operators.html`, both heavily rewritten since — resolved by keeping the current structure and re-applying the PR's payload (the DataTables `language:` i18n block, class renames, spacing).

## Regression fixes (4th commit)

- **Controls layout** — the table still used the legacy `dom` option. Kept it (DT2's `layout` option wraps controls in a full-width flex row, which stretched the toolbar) and extended the same self-owned flex wrapper to the info/pagination row, which was stacking.
- **Expand triangle always shown** — `resetObjects()` gated its whole per-row loop on `hasClass('even')/'odd'`, which DT2 no longer sets (it stripes via CSS `:nth-child`), so `noHidden` was never applied. Also switched to `toggleClass` so the state can't go stale, and made `noHidden` hide the arrow with `visibility` rather than `display` so rows stay aligned.
- **Detail row cramped** — the `td.child` wrapper and the label/value cells inside it inherited the 120px column cap; the subtable had no width (`width:100%` was on a `<tr>`, which does nothing); the cells had no padding at all.
- **Ellipsis → detail row detection** — `isEllipsisActive` measured `innerText` on a canvas, which ignores inline images and mismeasures the flag glyph in the FlagEmojis-first stack. Now measures the laid-out contents via a Range, adding back the `::before` control arrow and comparing against the content box rather than the padding box.
- **Sort arrows** — DT2 added its own indicator span to every header even though all columns are `orderable:false` and sorting runs through the "Trier" dropdown; disabled via `ordering: {indicators:false, handler:false}` (the object form — a top-level `orderIndicators` is overwritten during init).
- **Date column** — never ellipsed, and DT2's automatic right-alignment of detected date/numeric columns disabled. Header rules are scoped to `#dataTable_wrapper`, since with scrolling on DataTables clones the header and strips the id.
- Restored a dead `.dataTables_filter input` rule (the mobile search-box width fix) to its DT2 selector — it was the last `dataTables_*` selector left.

Also carries the PR's `get_user()` → `getUser()` fix in `app.py`; `get_user` is defined nowhere, so `/admin/stations` currently raises `NameError` on main.

Supersedes #30.