### PR TITLE
Fix huge delays in multitrip, and simplify trip sorting

### DIFF
--- a/app.py
+++ b/app.py
@@ -203,6 +203,7 @@ from src.utils import (
     get_default_trip_visibility,
     current_user_is_friend_with,
     external_url,
+    parse_date,
 )
 from src.trips import (
     Trip,
@@ -7926,11 +7927,16 @@ def processPublicTrips(tripIds):
         # (which would raise TypeError when mixing dated and non-dated trips).
         dt = d["trip"]["utc_filtered_start_datetime"]
         if isinstance(dt, str):
-            return (1, dt)
+            # Adjust start datetime by departure delay (in seconds)
+            # TODO: remove this part here once the postgres query provides "actual_departure_time"
+            dt_obj = parse_date(dt)
+            departure_delay = d["trip"]["departure_delay"] or 0
+            dt_obj += timedelta(seconds=departure_delay)
+            return (1, dt_obj.strftime("%Y-%m-%d %H:%M:%S"))
         return (0 if dt == -1 else 2, "")
 
-    sortedTripList = sorted(tripList, key=lambda d: d["trip"]["uid"], reverse=True)
-    sortedTripList = sorted(sortedTripList, key=_pub_trip_sort_key, reverse=True)
+    sortedTripList = sorted(tripList, key=lambda d: d["trip"]["uid"])
+    sortedTripList = sorted(sortedTripList, key=_pub_trip_sort_key)
     
     priceDict = {
         "total_price": total_price, 

--- a/templates/public/multi_trip.html
+++ b/templates/public/multi_trip.html
@@ -223,7 +223,7 @@ function loadTrips() {
         contentType: 'application/json',
         data: JSON.stringify({ tripIds: {{ tripIds | tojson }} })
     }).done(function(data) {
-        tripsData = data[0].reverse();
+        tripsData = data[0];
         coloursData = data[2];
         // With a single user there is nothing to disambiguate: use the normal
         // per-type trip colours instead of per-user ones

--- a/templates/public/new_trip.html
+++ b/templates/public/new_trip.html
@@ -1082,23 +1082,8 @@ async function initializeMapAndTrips() {
 
     var trips = response[0];
     var prices = response[1];
-    // A plan arrives already ordered (sort_order, then day/time) and that order is
-    // authored by the user — keep it verbatim. Real trips get the chronological sort.
-    if (!relativeDates) {
-        trips.reverse();
-        trips.sort(function(a, b) {
-          // Block order first (past, dated, future); within the dated block, chronological.
-          if (tripGroup(a) !== tripGroup(b)) return tripGroup(a) - tripGroup(b);
-          var getKey = function(t) {
-            try {
-              var dt = t.trip.utc_filtered_start_datetime;
-              var ts = new Date(String(dt).replace(' ', 'T') + 'Z').getTime();
-              return isNaN(ts) ? 0 : ts + (t.trip.departure_delay || 0) * 1000;
-            } catch(e) { return 0; }
-          };
-          return getKey(a) - getKey(b);
-        });
-    }
+    // Trips from getPublicTrips (and thus from processPublicTrips) already come sorted by actual_departure_time (i.e. departure_time + departure_delay).
+    // Therefor, no need to sort them here.
 
     // Keep a reference for itinerary<->map linking, and number the transfer points.
     currentTrips = trips;


### PR DESCRIPTION
https://trainlog.me/public/multiTrip/870756,870740 has some visual issues.

My thought process / findings in the code that led to this PR:
- multiTrip relies on the order from `processPublicTrips` (at least for the colored circle)
- `processPublicTrips` already sorts by planned departure -> this should be changed to actual departure time
- multiTrip including the above link work now
- `new_trip.html` also uses `processPublicTrips`, but does another round of sorting afterwards in js. This is now not needed anymore -> drop the sorting in js there
- `processPublicTrips` sorts with `reverse=True` and both multiTrip and new_trip reverse the result again. This is unnecessary and can be dropped. -> do so