### PR TITLE
Fix empty countries chart for accumulated delay

### DIFF
--- a/src/sql/stats/stats_countries.sql
+++ b/src/sql/stats/stats_countries.sql
@@ -14,6 +14,7 @@ SELECT
     carbon,
     arrival_delay,
     departure_delay,
+    COALESCE(arrival_delay, 0) - COALESCE(departure_delay, 0) AS added_duration,
     is_past AS "past",
     is_planned_future AS "plannedFuture"
 FROM time_categories


### PR DESCRIPTION
On the stats page, the countries chart was empty for the accumulated delay metric (`/u/<user>/stats/all/train/delayAccumulated`).

The per-country split in `src/api/stats.py` reads each trip's accumulated delay from an `added_duration` column (`COUNTRY_SPLIT_COLUMNS`), but `stats_countries.sql` never selected that column, so every trip contributed zero and all countries ended up empty. Every other stats query computes `arrival_delay - departure_delay` itself, which is why only the countries chart was affected.

This adds the column to the countries query using the same formula as the other queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)