### PR TITLE
Fix country:NO search matching every trip with an electrification split

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,7 +201,12 @@ from src.global_map import (
 from src.operators import find_operator_ids, get_trip_operator_logos
 from src.pg import setup_db, pg_session
 from src.search_terms import like_pattern
-from src.trip_search import base_type_filter, filter_conditions, parse_filters
+from src.trip_search import (
+    base_type_filter,
+    country_code_pattern,
+    filter_conditions,
+    parse_filters,
+)
 from src.suspicious_activity import (
     check_denied_login,
     log_denied_login,
@@ -8992,7 +8997,6 @@ def get_trips_api_internal(username, is_public=False):
             "origin_station",
             "destination_station",
             "COALESCE(operator, '')",
-            "COALESCE(countries, '')",
             "COALESCE(line_name, '')",
             "COALESCE(CAST(start_datetime AS text), '')",
             "COALESCE(CAST(end_datetime AS text), '')",
@@ -9006,6 +9010,9 @@ def get_trips_api_internal(username, is_public=False):
             "COALESCE(model, '')",
         ]
         terms = [like.format(col=col) for col in global_search_columns]
+        # The countries column is JSON keyed by code, matched on the quoted, upper-case
+        # code so that "NO" does not find every trip with a "nonelec" split.
+        terms.append(f"COALESCE(countries, '') LIKE :{param}_country")
         terms.append(
             "EXISTS (SELECT 1 FROM tickets tk WHERE tk.uid = FilteredTrips.ticket_id"
             f" AND remove_diacritics(LOWER(COALESCE(tk.name, ''))) LIKE remove_diacritics(LOWER(:{param})))"
@@ -9033,6 +9040,7 @@ def get_trips_api_internal(username, is_public=False):
 
     if search_value:
         search_params["search"] = like_pattern(search_value)
+        search_params["search_country"] = country_code_pattern(search_value)
         global_operator_ids = find_operator_ids(search_value)
         if global_operator_ids:
             search_params["search_operator_ids"] = global_operator_ids
@@ -9049,6 +9057,7 @@ def get_trips_api_internal(username, is_public=False):
     for idx, neg_term in enumerate(global_not_terms):
         neg_param = f"search_not_{idx}"
         search_params[neg_param] = like_pattern(neg_term)
+        search_params[f"{neg_param}_country"] = country_code_pattern(neg_term)
         # Exclude by alias too, so "!SBB" also drops trips logged as CFF — otherwise
         # a negative filter would leave behind the spellings it looks equivalent to.
         neg_operator_ids = find_operator_ids(neg_term)

--- a/src/trip_search.py
+++ b/src/trip_search.py
@@ -36,6 +36,7 @@ FILTER_FIELDS = {
 # either: a comparison would read a hidden value out one answer at a time.
 PUBLIC_HIDDEN_FIELDS = {"price"}
 
+
 # Station names are stored with the country flag in front of them ("🇳🇴 Oslo S"), which
 # a substring match never notices but an exact or anchored one would fail on. Both are
 # compared against the name alone, the same way the ordering sorts on it.
@@ -46,13 +47,24 @@ def _unflagged(column):
     )
 
 
+def country_code_pattern(term, exact=False):
+    """The LIKE pattern finding `term` among the codes of the countries column.
+
+    The column is JSON text keyed by country code, {"NO": 24497.5} or
+    {"NO": {"elec": 0, "nonelec": 24497.5}}, so a code always sits between double
+    quotes and in upper case, while the keys of a value are lower case. Matching the
+    quotes and the case, on the raw text, keeps "NO" out of "nonelec"; the match must
+    therefore stay case-sensitive.
+    """
+    return '%"' + like_pattern(term.upper(), exact=exact) + '"%'
+
+
 # Fields matched as plain text, with the expression each one matches against. The
 # COALESCE ones are nullable; a bare column never is.
 _TEXT_FIELDS = {
     "type": "type",
     "origin_station": _unflagged("origin_station"),
     "destination_station": _unflagged("destination_station"),
-    "countries": "countries",
     "visibility": "visibility",
     "line_name": "COALESCE(line_name, '')",
     "reg": "COALESCE(reg, '')",
@@ -124,6 +136,11 @@ def _value_predicate(field, value, exact, param):
                 return "visibility IS NULL", {}
             return f"LOWER({expression}) = LOWER(:{param})", params
         return _like(expression, param), params
+
+    if field == "countries":
+        # One of the codes, not the list as a whole: `country:\`NO\`` is "crosses
+        # Norway", and matches a trip that also crosses Sweden.
+        return f"countries LIKE :{param}", {param: country_code_pattern(value, exact)}
 
     if field == "start_datetime":
         column = "COALESCE(to_char(start_datetime, 'YYYY-MM-DD'), '')"


### PR DESCRIPTION
## What changed

`country:NO` in the trips smart search returned a large, seemingly random subset of trips instead of the trips through Norway. Every other country code behaved correctly.

The `countries` column is JSON text keyed by country code. Trips with an electrification split are stored as `{"DE": {"elec": 2644.4, "nonelec": 0}}`. The `country:` filter and the global free-text search ran a case-insensitive substring `LIKE` over that whole text, so `no` matched `nonelec` on every trip carrying the split. In a dev database that returned 1382 trips for the main user where only 79 actually cross Norway.

Both searches now match the code between its double quotes, case-sensitively, via a new `country_code_pattern` helper in `src/trip_search.py`:

- `country:NO`, `country:no` and `` country:`NO` `` all become `%"NO"%`.
- Wildcards keep working: `N*` becomes `%"N%"%`, which cannot reach `"nonelec"` because codes are upper case and the value keys are lower case.
- The global search binds its own quoted pattern for the countries column, for positive terms and `!term` exclusions alike.

## Verification

Ran the logged-in trips endpoint through Flask's test client against a dev database:

| Search | Before | After |
|---|---|---|
| `country:NO` / `country:no` / `` country:`NO` `` | 1382 | 79 |
| `country:!NO` | | 4434 |
| `country:N*` | | 199 |
| `country:elec` | | 0 |
| `country:BE` | 282 | 282 |

Ruff passes on both files.

## Note for reviewers

`src/sql/trips/get_trips_country.sql` still does a raw substring `LIKE` on the countries text for the per-country map page. It works today only because it is case-sensitive; not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)