### PR TITLE
Add missing use of language keys for trip types

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1241,7 +1241,7 @@ function renderRecords(d, scope) {
 }
 
 const TYPE_ORDER = ["train","tram","metro","bus","air","ferry","car","walk","cycle","helicopter","aerialway"];
-const TYPE_LABELS = {"train":"{{ train }}","tram":"{{ tram }}","metro":"{{ metro }}","bus":"{{ bus }}","air":"{{ air }}","ferry":"{{ ferry }}","car":"{{ car }}","walk":"{{ walk }}","cycle":"{{ cycle }}","helicopter":"{{ helicopter }}","aerialway":"{{ aerialway }}","accommodation":"{{ accommodation }}","poi":"{{ poi }}","restaurant":"{{ restaurant }}"};
+const TYPE_LABELS = {"train":"{{ train }}","tram":"{{ tram }}","metro":"{{ metro }}","funicular":"{{ funicular }}","rail":"{{ rail }}","air":"{{ air }}","bus":"{{ bus }}","ferry":"{{ ferry }}","helicopter":"{{ helicopter }}","aerialway":"{{ aerialway }}","walk":"{{ walk }}","cycle":"{{ cycle }}","ski":"{{ ski }}","scooter":"{{ scooter }}","car":"{{ car }}","other":"{{ other }}","accommodation":"{{ accommodation }}","poi":"{{ poi }}","restaurant":"{{ restaurant }}"};
 
 function barRow(label, value, pct, color) {
   return `<div class="bar-row">

--- a/templates/here_routing.html
+++ b/templates/here_routing.html
@@ -121,18 +121,22 @@ function buildItinerary(trips, prices){
   var total_string = []
 
   var text = {
-    "air" : "{{air}}",
-    "train" : "{{train}}",
-    "bus" : "{{bus}}",
-    "ferry" : "{{ferry}}",
-    "car" : "{{car}}",
-    "cycle" : "{{cycle}}",
-    "walk" : "{{walk}}",
-    "aerialway": '{{aerialway}}',
-    "scooter": '{{scooter}}',
-    "funicular": '{{funicular}}',
-    "rail": '{{rail}}',
-    "ski": '{{ski}}',
+    "train": "{{train}}",
+    "tram": "{{tram}}",
+    "metro": "{{metro}}",
+    "funicular": "{{funicular}}",
+    "rail": "{{rail}}",
+    "air": "{{air}}",
+    "bus": "{{bus}}",
+    "ferry": "{{ferry}}",
+    "helicopter": "{{helicopter}}",
+    "aerialway": "{{aerialway}}",
+    "walk": "{{walk}}",
+    "cycle": "{{cycle}}",
+    "ski": "{{ski}}",
+    "scooter": "{{scooter}}",
+    "car": "{{car}}",
+    "other": "{{other}}",
   }
 
 {% if 'price' in request.args %}              

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -317,19 +317,26 @@
         }
     };
 
-    // Trip type labels for combined mode
+    // Trip type labels for combined mode. distinctTypes only lists types the
+    // user has trips of (and is empty for a logged-out public viewer), so
+    // fall back to the lang key rather than the raw code.
     const TRIP_TYPE_LABELS = {
-        'air': '{{distinctTypes.air.label if distinctTypes.air else "Air"}}',
-        'helicopter': '{{distinctTypes.helicopter.label if distinctTypes.helicopter else "Helicopter"}}',
-        'train': '{{distinctTypes.train.label if distinctTypes.train else "Train"}}',
-        'tram': '{{distinctTypes.tram.label if distinctTypes.tram else "Tram"}}',
-        'metro': '{{distinctTypes.metro.label if distinctTypes.metro else "Metro"}}',
-        'bus': '{{distinctTypes.bus.label if distinctTypes.bus else "Bus"}}',
-        'ferry': '{{distinctTypes.ferry.label if distinctTypes.ferry else "Ferry"}}',
-        'car': '{{distinctTypes.car.label if distinctTypes.car else "Car"}}',
-        'cycle': '{{distinctTypes.cycle.label if distinctTypes.cycle else "Cycle"}}',
-        'walk': '{{distinctTypes.walk.label if distinctTypes.walk else "Walk"}}',
-        'aerialway': '{{distinctTypes.aerialway.label if distinctTypes.aerialway else "Aerialway"}}'
+        'train': '{{distinctTypes.train.label if distinctTypes.train else train}}',
+        'tram': '{{distinctTypes.tram.label if distinctTypes.tram else tram}}',
+        'metro': '{{distinctTypes.metro.label if distinctTypes.metro else metro}}',
+        'funicular': '{{distinctTypes.funicular.label if distinctTypes.funicular else funicular}}',
+        'rail': '{{distinctTypes.rail.label if distinctTypes.rail else rail}}',
+        'air': '{{distinctTypes.air.label if distinctTypes.air else air}}',
+        'bus': '{{distinctTypes.bus.label if distinctTypes.bus else bus}}',
+        'ferry': '{{distinctTypes.ferry.label if distinctTypes.ferry else ferry}}',
+        'helicopter': '{{distinctTypes.helicopter.label if distinctTypes.helicopter else helicopter}}',
+        'aerialway': '{{distinctTypes.aerialway.label if distinctTypes.aerialway else aerialway}}',
+        'walk': '{{distinctTypes.walk.label if distinctTypes.walk else walk}}',
+        'cycle': '{{distinctTypes.cycle.label if distinctTypes.cycle else cycle}}',
+        'ski': '{{distinctTypes.ski.label if distinctTypes.ski else ski}}',
+        'scooter': '{{distinctTypes.scooter.label if distinctTypes.scooter else scooter}}',
+        'car': '{{distinctTypes.car.label if distinctTypes.car else car}}',
+        'other': '{{distinctTypes.other.label if distinctTypes.other else other}}'
     };
 
     // Available trip types from backend


### PR DESCRIPTION
## What changed

- `templates/stats.html`: the combined-mode label map now covers all 16 journey types. Each entry uses the `distinctTypes` label when present and falls back to the lang key (`{{ train }}` etc.) instead of a hard-coded English string.
- `templates/dashboard.html`: `TYPE_LABELS` gained funicular, rail, ski, scooter and other, so the money and CO₂ bars no longer show raw codes.
- `templates/here_routing.html`: the per-type tooltip map gained tram, metro, helicopter and other, which previously rendered as `undefined: 12 km`.

All three maps are now in the same order as the new-trip menu in `navigation.html`.

## Why

On `/u/<user>/stats/all/combined/trips` the chart legend showed `funicular`, `scooter` and `rail` verbatim. The map was keyed off `distinctTypes`, which only listed 11 types, and the fallback was the raw code. `distinctTypes` is also empty for a logged-out viewer of a public stats page, so the fallback there was English regardless of language.

## Reviewer notes

Every lang file has all 16 keys and none of the values contain quote characters, so the JS string literals are safe. The other trip-type label maps (map, current, new_map, public trip, new trip, poster, current_global, dynamic_trips) were already complete and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)