### PR TITLE
Add Open Graph title and description to shared plan pages

### DIFF
--- a/app.py
+++ b/app.py
@@ -5897,6 +5897,36 @@ def _render_plan_view(plan, username, controls):
     (not the site owner, which `owner` means everywhere else in this module)."""
     user = User.query.filter_by(username=username).first() if username else None
     author_username = get_username(plan["user_id"])
+
+    # The page shell only needs per-leg countries/length for the OG tags — the
+    # legs themselves are fetched by the client from planDataUrl.
+    with pg_session() as pg:
+        rows = pg.execute(
+            """
+            SELECT countries, trip_length
+            FROM plan_trips
+            WHERE plan_id = :plan_id
+            ORDER BY sort_order, uid
+            """,
+            {"plan_id": plan["uid"]},
+        ).fetchall()
+    countries = []
+    length = 0
+    for row in rows:
+        row_countries = row["countries"]
+        if isinstance(row_countries, str):
+            row_countries = json.loads(row_countries)
+        for country in (row_countries or {}).keys():
+            if country not in countries:
+                countries.append(country)
+        length += row["trip_length"] or 0
+
+    # Open Graph info
+    og = {}
+    displayCountries = " ".join([get_flag_emoji(c) for c in countries])
+    og["title"] = plan["name"]
+    og["description"] = f"{round(length / 1000)} km in {displayCountries}"
+    # TODO: og["image"] — og_image_url/og_card only draw trips+paths rows, not plan_trips.
     data_url = (
         url_for("get_plan_trips_json", username=author_username, plan_uuid=plan["uuid"])
         if controls
@@ -5918,10 +5948,10 @@ def _render_plan_view(plan, username, controls):
         title=plan["name"],
         collection_voyage="voyage",
         tag_description=plan["name"],
-        special_og=False,
+        special_og=True,
         tileserver=user.tileserver if user else "default",
         globe=user.globe if user else False,
-        og={},
+        og=og,
         num_hidden_trips=0,
         colorblind=getattr(user, "colorblind", False) if user else False,
         planDataUrl=data_url,


### PR DESCRIPTION
Resolves https://trainlog.me/feature_requests/276.

## What changed

A shared plan link (`/public/plan/<uuid>`) now unfurls on Discord, Signal etc. the same way a tag link does:

- `og:title` is the plan's name.
- `og:description` is the plan's total length and the flags of the countries it crosses, e.g. `1016 km in 🇩🇪 🇫🇷`, in the same format the tag preview uses.

## How

`_render_plan_view` reads per-leg `countries` and `trip_length` from `plan_trips` in one set-based query and builds the OG dict in the same shape as `render_public_trip_page`. The legs themselves are still fetched by the client, so the page shell stays light. `special_og` is now on for the plan view so the layout emits the specific text.

## Reviewer notes

- No `og:image` yet. `og_image_url` and `src/og_card.py` address and draw trips by id from the `trips`/`paths` tables, and plan legs live in `plan_trips` with inline geometry. Left as a one-line TODO; a plan image needs its own `/og/plan/<uuid>.png` route and a plan-aware fetch in the card renderer.
- Verified locally with the Flask test client: a three-leg plan (one leg with no length or countries) renders the expected title and description; an empty plan renders `0 km in `.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
