### PR TITLE
Keep exact empty search values so "material:``" lists unset trips again

### DIFF
--- a/src/trip_search.py
+++ b/src/trip_search.py
@@ -74,7 +74,10 @@ def parse_filters(raw, is_public=False):
         if not isinstance(entry, dict):
             continue
         field = entry.get("field")
-        values = [str(v) for v in entry.get("values", []) if str(v)]
+        exact = bool(entry.get("exact"))
+        # An exact empty value ("material:``") asks for trips where the field is
+        # not set, so it is kept; a partial one would match everything and is dropped.
+        values = [str(v) for v in entry.get("values", []) if exact or str(v)]
         if field not in FILTER_FIELDS or not values:
             continue
         if is_public and field in PUBLIC_HIDDEN_FIELDS:
@@ -83,7 +86,7 @@ def parse_filters(raw, is_public=False):
             {
                 "field": field,
                 "values": values,
-                "exact": bool(entry.get("exact")),
+                "exact": exact,
                 "negate": bool(entry.get("negate")),
             }
         )


### PR DESCRIPTION
Searching for ``` material:`` ``` used to list the trips without a vehicle type. Since the search parsing moved from `app.py` into `src/trip_search.py`, `parse_filters` dropped every empty value, so that exact filter vanished and the listing fell back to all trips.

Empty values are now kept when the filter is exact, which is how a user asks for trips where the field is not set. Partial empty values stay dropped, since they would match everything. The generated SQL for the exact empty case is the same as before the refactor.

🤖 Generated with [Claude Fable 5.1](https://claude.com/claude-code)