### PR TITLE
Add day pseudo-tags (alongside year, month and week)

### DIFF
--- a/app.py
+++ b/app.py
@@ -4761,7 +4761,7 @@ def render_public_trip_page(
         )
 
     if tripIds is None and period is not None:
-        # A year/month/week pseudo-tag: resolved on every request, so a trip
+        # A year/month/week/day pseudo-tag: resolved on every request, so a trip
         # logged later simply appears on the page for its period.
         try:
             start, end = parse_period(period["kind"], period["period"])
@@ -5059,10 +5059,10 @@ def public_trip_poster(tripIds=None, tagId=None, ticketId=None):
     )
 
 
-# Pseudo-tags: every trip in a year, month or ISO week, matched on local
+# Pseudo-tags: every trip in a year, month, ISO week or day, matched on local
 # departure time. Nothing is stored — the list is rebuilt on each request, so
 # these pages stay current without cluttering the tag list.
-@app.route("/public/<username>/<any(year, month, week):kind>/<period>")
+@app.route("/public/<username>/<any(year, month, week, day):kind>/<period>")
 @public_required
 def public_trip_period(username, kind, period):
     return render_public_trip_page(
@@ -5071,7 +5071,7 @@ def public_trip_period(username, kind, period):
     )
 
 
-@app.route("/public/<username>/<any(year, month, week):kind>/<period>/poster")
+@app.route("/public/<username>/<any(year, month, week, day):kind>/<period>/poster")
 @public_required
 def public_trip_period_poster(username, kind, period):
     return render_public_trip_page(
@@ -5081,7 +5081,7 @@ def public_trip_period_poster(username, kind, period):
     )
 
 
-@app.route("/public/multiTrip/<username>/<any(year, month, week):kind>/<period>")
+@app.route("/public/multiTrip/<username>/<any(year, month, week, day):kind>/<period>")
 @public_required
 def multi_trip_period(username, kind, period):
     return multi_trip(period={"username": username, "kind": kind, "period": period})
@@ -12730,8 +12730,8 @@ def _own_period_redirect(kind, period):
 
 
 # Typing just a period at the root is a shortcut to your own trips for it:
-# /2026, /year/2026, /month/2026-10, /week/2026-W40.
-@app.route("/<any(year, month, week):kind>/<period>")
+# /2026, /year/2026, /month/2026-10, /week/2026-W40, /day/2026-10-01.
+@app.route("/<any(year, month, week, day):kind>/<period>")
 def own_trip_period(kind, period):
     return _own_period_redirect(kind, period)
 

--- a/src/api/og.py
+++ b/src/api/og.py
@@ -168,7 +168,9 @@ def _serve(name, trip_ids, title=None):
     png = render_og_card(name, ids, title or auto_title, subtitle, countries)
     if png is None:
         return _logo()
-    return Response(png, mimetype="image/jpeg", headers={"Cache-Control": CACHE_CONTROL})
+    return Response(
+        png, mimetype="image/jpeg", headers={"Cache-Control": CACHE_CONTROL}
+    )
 
 
 @og_blueprint.route("/og/trip/<trip_ids>.<any(png, jpg):ext>")
@@ -229,7 +231,9 @@ def tag_image(uuid, ext):
     return _serve(f"tag-{uuid}", row["trip_ids"], title=row["name"])
 
 
-@og_blueprint.route("/og/<username>/<any(year, month, week):kind>/<period>.<any(png, jpg):ext>")
+@og_blueprint.route(
+    "/og/<username>/<any(year, month, week, day):kind>/<period>.<any(png, jpg):ext>"
+)
 def period_image(username, kind, period, ext):
     try:
         start, end = parse_period(kind, period)
@@ -319,4 +323,6 @@ def plan_image(uuid, ext):
     )
     if png is None:
         return _logo()
-    return Response(png, mimetype="image/jpeg", headers={"Cache-Control": CACHE_CONTROL})
+    return Response(
+        png, mimetype="image/jpeg", headers={"Cache-Control": CACHE_CONTROL}
+    )

--- a/src/trip_periods.py
+++ b/src/trip_periods.py
@@ -1,4 +1,4 @@
-"""Date-range pseudo-tags: every trip a user made in a year, month or week.
+"""Date-range pseudo-tags: every trip a user made in a year, month, week or day.
 
 These behave like a tag that nobody has to create and that nobody has to keep
 up to date — the id list is resolved on every request, so a trip logged later
@@ -7,6 +7,7 @@ shows up on the page it belongs to:
     /public/simfr24/year/2026
     /public/simfr24/month/2026-10
     /public/simfr24/week/2026-W40
+    /public/simfr24/day/2026-10-01
 
 The window is matched against ``start_datetime``, which is the trip's local
 departure time, so a 23:30 departure belongs to the day it felt like rather
@@ -22,11 +23,12 @@ from datetime import date, datetime, timedelta
 
 from src.pg import pg_session
 
-KINDS = ("year", "month", "week")
+KINDS = ("year", "month", "week", "day")
 
 _YEAR_RE = re.compile(r"^(\d{4})$")
 _MONTH_RE = re.compile(r"^(\d{4})-(\d{2})$")
 _WEEK_RE = re.compile(r"^(\d{4})-[Ww](\d{2})$")
+_DAY_RE = re.compile(r"^(\d{4})-(\d{2})-(\d{2})$")
 
 # Trips are logged well before and after today, but not in the year 3000.
 MIN_YEAR, MAX_YEAR = 1800, 2999
@@ -69,6 +71,19 @@ def parse_period(kind: str, value: str):
         start = datetime(monday.year, monday.month, monday.day)
         return start, start + timedelta(days=7)
 
+    if kind == "day":
+        match = _DAY_RE.match(value or "")
+        if not match:
+            raise ValueError(f"bad day: {value!r}")
+        year = _check_year(int(match.group(1)))
+        month, day = int(match.group(2)), int(match.group(3))
+        try:
+            # Catches 2026-02-30 and friends, which the regex is happy with.
+            start = datetime(year, month, day)
+        except ValueError as exc:
+            raise ValueError(f"bad day: {value!r}") from exc
+        return start, start + timedelta(days=1)
+
     raise ValueError(f"bad period kind: {kind!r}")
 
 
@@ -79,7 +94,7 @@ def _check_year(year: int) -> int:
 
 
 def period_label(kind: str, value: str) -> str:
-    """Canonical label for the page title — "2026", "2026-10", "2026-W40"."""
+    """Canonical label for the title — "2026", "2026-10", "2026-W40", "2026-10-01"."""
     if kind == "week":
         year, week = _WEEK_RE.match(value).groups()
         return f"{year}-W{week}"


### PR DESCRIPTION
Adds `day` to the date-range pseudo-tags, in the same shape as year, month and week: `/day/2026-10-01` redirects to your own page, `/public/<user>/day/2026-10-01` works with the poster, the multiTrip view and the OG image.

The `YYYY-MM-DD` regex accepts `2026-02-30`, so the window is built through `datetime()` and a bad date 404s like the other kinds.

The `Response(...)` reformats in `src/api/og.py` are the ruff-format hook on pre-existing lines.